### PR TITLE
Add option to write output to a file and fix minor TypeScript coding style & formatting issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ json into beautiful typescript...until now.
 
 Noctilucent will take your json and output the equivalent typescript.
 
+## User Guide
+```
+cargo build --release
+./target/release/noctilucent <INPUT> <OUTPUT>
+```
+* `INPUT` is the input file path.
+* `OUTPUT` is the output file path; if not specified, output will be printed on your command line.
+
 ## Implemented
 
 - [x] Fn::FindInMap

--- a/src/ir/importer.rs
+++ b/src/ir/importer.rs
@@ -27,7 +27,7 @@ impl Importer {
             // We will always include the cdk, as it's used to build the stack.
             ImportInstruction {
                 name: "cdk".to_string(),
-                path: vec!["aws-cdk-lib".to_string()],
+                path: vec!["monocdk".to_string()],
             },
         ];
 
@@ -35,7 +35,7 @@ impl Importer {
             import_instructions.push(ImportInstruction {
                 name: type_name.service.to_string(),
                 path: vec![
-                    "aws-cdk-lib".to_string(),
+                    "monocdk".to_string(),
                     format!("{}-{}", type_name.organization, type_name.service).to_string(),
                 ],
             })

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,12 @@ fn main() {
                 .required(true)
                 .index(1),
         )
+        .arg(
+            Arg::new("OUTPUT")
+                .help("Sets the output file to use")
+                .required(false)
+                .index(2),
+        )
         .get_matches();
 
     let txt_location: &str = matches.value_of("INPUT").unwrap();
@@ -24,5 +30,11 @@ fn main() {
 
     let cfn_tree = CloudformationParseTree::build(&value).unwrap();
     let ir = CloudformationProgramIr::new_from_parse_tree(&cfn_tree).unwrap();
-    TypescriptSynthesizer::output(ir);
+    let output: String = TypescriptSynthesizer::output(ir);
+
+    if matches.is_present("OUTPUT") {
+        fs::write(matches.value_of("OUTPUT").unwrap(), output).expect("Unable to write file");
+    } else {
+        println!("{}", output);
+    }
 }

--- a/src/parser/lookup_table.rs
+++ b/src/parser/lookup_table.rs
@@ -62,10 +62,10 @@ pub enum MappingInnerValue {
 impl Display for MappingInnerValue {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         return match self {
-            MappingInnerValue::String(string_val) => write!(f, "\"{}\"", string_val),
+            MappingInnerValue::String(string_val) => write!(f, "'{}'", string_val),
             MappingInnerValue::List(list_val) => {
                 let quoted_list_values: Vec<String> =
-                    list_val.iter().map(|val| format!("\"{}\"", val)).collect();
+                    list_val.iter().map(|val| format!("'{}'", val)).collect();
                 write!(f, "[{}]", quoted_list_values.join(","))
             }
         };
@@ -123,7 +123,7 @@ fn convert_to_string_vector(
                         "List values for mappings must be a string. Found {:?}, for key {}",
                         inner_key, vector_val
                     ),
-                })
+                });
             }
         };
         string_vector.push(converted_val);

--- a/src/synthesizer/typescript_synthesizer.rs
+++ b/src/synthesizer/typescript_synthesizer.rs
@@ -12,46 +12,63 @@ pub struct TypescriptSynthesizer {
 }
 
 impl TypescriptSynthesizer {
-    pub fn output(ir: CloudformationProgramIr) {
+    pub fn output(ir: CloudformationProgramIr) -> String {
+        let output = &mut String::new();
+
         for import in ir.imports {
-            println!(
+            append_str_with_linebreak(output, &format!(
                 "import * as {} from '{}';",
                 import.name,
                 import.path.join("/")
-            )
+            ));
         }
         // Static imports with base assumptions (e.g. using base 64)
-        println!("import {{Buffer}} from 'buffer';");
+        append_str_with_linebreak(output, "import {Buffer} from 'buffer';");
+        append_str_with_linebreak(output, "\n// Interfaces");
+        append_str_with_linebreak(output, "export interface NoctStackProps extends cdk.StackProps {");
 
-        println!("export interface NoctStackProps extends cdk.StackProps {{");
         for param in ir.constructor.inputs {
-            println!(
-                "\treadonly {}: {}",
+            append_str_with_linebreak(output, &format!(
+                "\treadonly {}: {};",
                 camel_case(&param.name),
                 camel_case(&param.constructor_type)
-            )
+            ));
         }
-        println!("}}");
-        println!("export class NoctStack extends cdk.Stack {{");
-        println!("\tconstructor(scope: cdk.App, id: string, props: NoctStackProps){{");
-        println!("\t\tsuper(scope, id, props);");
+
+        append_str_with_linebreak(output, "}");
+        append_str_with_linebreak(output, "\n// Stack");
+        append_str_with_linebreak(output, "export class NoctStack extends cdk.Stack {");
+        append_str_with_linebreak(output, "\tconstructor(scope: cdk.App, id: string, props: NoctStackProps) {");
+        append_str_with_linebreak(output, "\t\tsuper(scope, id, props);");
+        append_str_with_linebreak(output, "\n\t\t// Mappings");
+
         for mapping in ir.mappings.iter() {
             let record_type = match mapping.find_first_type() {
                 MappingInnerValue::String(_) => "Record<string, Record<string, string>>",
                 MappingInnerValue::List(_) => "Record<string, Record<string, Array<string>>>",
             };
-            println!(
-                "const {}: {} = {}",
+
+            append_str_with_linebreak(output, &format!(
+                "\t\tconst {}: {} = {};",
                 camel_case(&mapping.name),
                 record_type,
-                synthesize_mapping_instruction(mapping)
-            );
+                synthesize_mapping_instruction(mapping),
+            ));
         }
+
+        append_str_with_linebreak(output, "\n\t\t// Conditions");
 
         for cond in ir.conditions {
             let synthed = synthesize_condition_recursive(&cond.value);
-            println!("const {} = {};", camel_case(&cond.name), synthed)
+
+            append_str_with_linebreak(output, &format!(
+                "\t\tconst {} = {};",
+                camel_case(&cond.name),
+                synthed
+            ));
         }
+
+        append_str_with_linebreak(output, "\n\t\t// Resources");
 
         for reference in ir.resources.iter() {
             let mut split_ref = reference.resource_type.split("::");
@@ -60,107 +77,128 @@ impl TypescriptSynthesizer {
             let rtype = split_ref.next().unwrap();
 
             if let Some(x) = &reference.condition {
-                println!("if ({}){{", camel_case(x));
+                append_str_with_linebreak(output, &format!("\t\tif ({}) {{", camel_case(x)));
             }
 
-            println!(
-                "let {} = new {}.Cfn{}(this, '{}', {{",
+            append_str_with_linebreak(output, &format!(
+                "\t\tconst {} = new {}.Cfn{}(this, '{}', {{",
                 camel_case(&reference.name),
                 service,
                 rtype,
-                reference.name
-            );
+                reference.name,
+            ));
 
-            for (name, prop) in reference.properties.iter() {
+            for (i, (name, prop)) in reference.properties.iter().enumerate() {
                 match to_string_ir(prop) {
                     None => {}
                     Some(x) => {
-                        println!("\t{}:{},", camel_case(name), x);
+                        append_str_with_linebreak(output, &format!(
+                            "{}: {}{}",
+                            camel_case(name),
+                            x,
+                            // Remove trailing comma.
+                            if i == reference.properties.len() - 1 { "" } else { "," }
+                        ));
                     }
                 }
             }
-            println!("}});");
+
+            append_str_with_linebreak(output, "\t\t});");
 
             if let Some(metadata) = &reference.metadata {
-                println!("{}.addOverride('Metadata', ", camel_case(&reference.name));
+                append_str_with_linebreak(output, &format!("{}.addOverride('Metadata', ", camel_case(&reference.name)));
+
                 match to_string_ir(metadata) {
                     None => panic!("This should never fail"),
                     Some(x) => {
-                        println!("{}", x);
+                        append_str_with_linebreak(output, &format!("{}", x));
                     }
                 };
 
-                println!(");");
+                append_str_with_linebreak(output, ");");
             }
+
             if let Some(update_policy) = &reference.update_policy {
-                println!(
+                append_str_with_linebreak(output, &format!(
                     "{}.addOverride('UpdatePolicy', ",
-                    camel_case(&reference.name)
-                );
+                    camel_case(&reference.name),
+                ));
+
                 match to_string_ir(update_policy) {
                     None => panic!("This should never fail"),
                     Some(x) => {
-                        println!("{}", x);
+                        append_str_with_linebreak(output, &format!("{}", x));
                     }
                 };
-                println!(");");
+
+                append_str_with_linebreak(output, ");");
             }
 
             if let Some(deletion_policy) = &reference.deletion_policy {
-                println!(
+                append_str_with_linebreak(output, &format!(
                     "{}.addOverride('DeletionPolicy', '{}');",
                     camel_case(&reference.name),
-                    deletion_policy
-                );
+                    deletion_policy,
+                ));
             }
+
             if !reference.dependencies.is_empty() {
-                println!("{}.addOverride('DependsOn', [", camel_case(&reference.name));
+                append_str_with_linebreak(output, &format!("{}.addOverride('DependsOn', [", camel_case(&reference.name)));
 
                 let x: Vec<String> = reference
                     .dependencies
                     .iter()
                     .map(|x| format!("'{}'", x))
                     .collect();
-                println!("{}", x.join(","));
 
-                println!("]);");
+                append_str_with_linebreak(output, &format!("{}", x.join(",")));
+                append_str_with_linebreak(output, "]);");
             }
+
             if let Some(_x) = &reference.condition {
-                println!("}}")
+                append_str_with_linebreak(output, "}")
             }
         }
 
-        for output in ir.outputs {
-            println!("new cdk.CfnOutput(this, '{}', {{", output.name);
+        append_str_with_linebreak(output, "\n\t\t// Outputs");
 
-            let export_str = output.export.and_then(|x| to_string_ir(&x));
+        for op in ir.outputs {
+            append_str_with_linebreak(output, &format!("new cdk.CfnOutput(this, '{}', {{", op.name));
+
+            let export_str = op.export.and_then(|x| to_string_ir(&x));
+
             if let Some(export) = export_str {
-                println!("\texportName: {},", export);
+                append_str_with_linebreak(output, &format!("\texportName: {},", export));
             }
-            match to_string_ir(&output.value) {
+
+            match to_string_ir(&op.value) {
                 None => {
                     panic!("Can't happen")
                 }
                 Some(x) => {
-                    println!("\tvalue: {}", x);
+                    append_str_with_linebreak(output, &format!("\tvalue: {}", x));
                 }
             }
 
-            println!("}});");
+            append_str_with_linebreak(output, "});");
         }
 
-        println!("\t}}");
-        println!("}}");
+        append_str_with_linebreak(output, "\t}");
+        append_str_with_linebreak(output, "}");
+
+        return output.to_string();
     }
 }
 
+// The indent generated by this method is not perfect. You have to copy the generated code to an IDE
+// and use IDE to format.
 pub fn to_string_ir(resource_value: &ResourceIr) -> Option<String> {
     match resource_value {
         ResourceIr::Null => Option::None,
         ResourceIr::Bool(b) => Option::Some(b.to_string()),
         ResourceIr::Number(n) => Option::Some(n.to_string()),
         ResourceIr::String(s) => Option::Some(format!(
-            "\'{}\'",
+            "'{}'",
             s.replace('\'', "\\'").replace('\n', "\\n")
         )),
         ResourceIr::Array(_, arr) => {
@@ -172,7 +210,7 @@ pub fn to_string_ir(resource_value: &ResourceIr) -> Option<String> {
                 }
             }
 
-            Option::Some(format!("[{}]", v.join(",\n")))
+            Option::Some(format!("[\n{}\n]", v.join(",\n")))
         }
         ResourceIr::Object(complexity, o) => {
             // We are transforming to typescript-json which will not have quotes.
@@ -191,13 +229,13 @@ pub fn to_string_ir(resource_value: &ResourceIr) -> Option<String> {
                         {
                             v.push(format!("{}: {}", s, r));
                         } else {
-                            v.push(format!("\"{}\": {}", s, r));
+                            v.push(format!("'{}': {}", s, r));
                         }
                     }
                 }
             }
 
-            Option::Some(format!("{{{}}}", v.join(",\n")))
+            Option::Some(format!("{{\n{}\n}}", v.join(",\n")))
         }
         ResourceIr::Sub(arr) => {
             // Sub has two ways of being built: Either resolution via a bunch of objects
@@ -229,13 +267,17 @@ pub fn to_string_ir(resource_value: &ResourceIr) -> Option<String> {
                 None => String::from("{}"),
                 Some(x) => x,
             };
-
             let false_expr = match to_string_ir(false_expr) {
                 None => String::from("{}"),
                 Some(x) => x,
             };
 
-            Option::Some(format!("({})?{}:{}", bool_expr, true_expr, false_expr))
+            if false_expr == "{}" || false_expr == "[]" {
+                // false_expr here ("{}" or "[]") might give a type mismatch error so we remove it.
+                Option::Some(format!("{}", true_expr))
+            } else {
+                Option::Some(format!("{} ? {} : {}", bool_expr, true_expr, false_expr))
+            }
         }
         ResourceIr::Join(sep, join_obj) => {
             let mut strs = Vec::new();
@@ -246,7 +288,7 @@ pub fn to_string_ir(resource_value: &ResourceIr) -> Option<String> {
                 }
             }
 
-            Option::Some(format!("{}.join(\"{}\")", strs.join(","), sep))
+            Option::Some(format!("{}.join('{}')", strs.join(","), sep))
         }
         ResourceIr::Ref(x) => Option::Some(x.synthesize()),
         ResourceIr::Base64(x) => {
@@ -282,7 +324,7 @@ fn synthesize_condition_recursive(val: &ConditionIr) -> String {
         }
         ConditionIr::Equals(a, b) => {
             format!(
-                "{} == {}",
+                "{} === {}",
                 synthesize_condition_recursive(a.as_ref()),
                 synthesize_condition_recursive(b.as_ref())
             )
@@ -301,7 +343,7 @@ fn synthesize_condition_recursive(val: &ConditionIr) -> String {
             format!("({})", inner)
         }
         ConditionIr::Str(x) => {
-            format!("\"{}\"", x)
+            format!("'{}'", x)
         }
         ConditionIr::Ref(x) => x.synthesize(),
         ConditionIr::Map(named_resource, l1, l2) => {
@@ -325,7 +367,7 @@ fn synthesize_mapping_instruction(mapping_instruction: &MappingInstruction) -> S
     let mut outer_records = Vec::new();
     for (outer_mapping_key, inner_mapping) in mapping_instruction.map.iter() {
         outer_records.push(format!(
-            "\t\"{}\": {}",
+            "\t\t\t'{}': {}",
             outer_mapping_key,
             synthesize_inner_mapping(inner_mapping)
         ));
@@ -333,7 +375,7 @@ fn synthesize_mapping_instruction(mapping_instruction: &MappingInstruction) -> S
 
     let outer = outer_records.join(",\n");
     mapping_parse_tree_ts.push_str(&outer);
-    mapping_parse_tree_ts.push_str("\n};\n");
+    mapping_parse_tree_ts.push_str("\n\t\t}");
     mapping_parse_tree_ts
 }
 
@@ -342,11 +384,16 @@ fn synthesize_inner_mapping(inner_mapping: &HashMap<String, MappingInnerValue>) 
     let mut inner_mapping_entries = Vec::new();
     for (inner_mapping_key, inner_mapping_value) in inner_mapping {
         inner_mapping_entries.push(format!(
-            "\t\t\"{}\": {}",
-            inner_mapping_key, inner_mapping_value
+            "\t\t\t\t'{}': {}",
+            inner_mapping_key,
+            inner_mapping_value
         ));
     }
     inner_mapping_ts_str.push_str(&inner_mapping_entries.join(",\n"));
-    inner_mapping_ts_str.push_str("\n\t}");
+    inner_mapping_ts_str.push_str("\n\t\t\t}");
     inner_mapping_ts_str
+}
+
+fn append_str_with_linebreak(result: &mut String, string: &str) {
+    result.push_str(&format!("{}\n", string));
 }


### PR DESCRIPTION
Tested using my own CloudFormation template. The input file is so huge that it is painful to copy the output (which is also huge) from command line. So having the option to write the output to a file is nice.

I also fixed some minor TypeScript coding style & formatting issues after inspecting the output using eslint.