### PR TITLE
Add capability to parse and convert floats in CFN templates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 clap = "3.0.0-beta.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+numberkit = "0.1.0"
 nom = "7.0.0"
 voca_rs = "1.14.0"
 topological-sort = "0.1.0"

--- a/src/ir/resources.rs
+++ b/src/ir/resources.rs
@@ -1,5 +1,5 @@
 use crate::ir::reference::{Origin, Reference};
-use crate::parser::resource::ResourceValue;
+use crate::parser::resource::{ResourceValue, WrapperF64};
 use crate::parser::sub::{sub_parse_tree, SubValue};
 use crate::specification::{spec, Complexity, SimpleType, Specification};
 use crate::{CloudformationParseTree, TransmuteError};
@@ -16,6 +16,7 @@ pub enum ResourceIr {
     Null,
     Bool(bool),
     Number(i64),
+    Double(WrapperF64),
     String(String),
 
     // Higher level resolutions
@@ -166,7 +167,7 @@ fn find_dependencies(
     topo: &mut TopologicalSort<String>,
 ) {
     match resource {
-        ResourceIr::Null | ResourceIr::Bool(_) | ResourceIr::Number(_) | ResourceIr::String(_) => {}
+        ResourceIr::Null | ResourceIr::Bool(_) | ResourceIr::Number(_) | ResourceIr::Double(_) | ResourceIr::String(_) => {}
 
         ResourceIr::Array(_, arr) => {
             for x in arr {
@@ -229,6 +230,7 @@ pub fn translate_resource(
         ResourceValue::Null => Ok(ResourceIr::Null),
         ResourceValue::Bool(b) => Ok(ResourceIr::Bool(*b)),
         ResourceValue::Number(n) => Ok(ResourceIr::Number(*n)),
+        ResourceValue::Double(d) => Ok(ResourceIr::Double(*d)),
         ResourceValue::String(s) => {
             if let Complexity::Simple(simple_type) = &resource_translator.complexity {
                 return match simple_type {

--- a/src/synthesizer/typescript_synthesizer.rs
+++ b/src/synthesizer/typescript_synthesizer.rs
@@ -242,6 +242,7 @@ pub fn to_string_ir(resource_value: &ResourceIr) -> Option<String> {
         ResourceIr::Null => Option::None,
         ResourceIr::Bool(b) => Option::Some(b.to_string()),
         ResourceIr::Number(n) => Option::Some(n.to_string()),
+        ResourceIr::Double(d) => Option::Some(d.to_string()),
         ResourceIr::String(s) => {
             Option::Some(format!("'{}'", s.replace('\'', "\\'").replace('\n', "\\n")))
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -143,6 +143,50 @@ fn test_parse_tree_sub_list() {
     assert_resource_equal(a, resource);
 }
 
+#[test]
+fn test_parse_tree_resource_with_floats() {
+    let a = serde_json::json!({
+        "Alarm": {
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+                "AlarmName": {
+                    "Fn::Sub": [
+                        "${Tag}-FrontendDistributedCacheTrafficImbalanceAlarm",
+                        {
+                            "Tag": {
+                               "Ref": "AWS::Region"
+                            }
+                        }
+                    ]
+                },
+                "Threshold": 3.5
+            }
+        }
+    });
+
+    let resource = ResourceParseTree {
+        name: "Alarm".into(),
+        condition: Option::None,
+        resource_type: "AWS::CloudWatch::Alarm".into(),
+        metadata: Option::None,
+        update_policy: Option::None,
+        deletion_policy: Option::None,
+        dependencies: vec![],
+        properties: map! {
+            "AlarmName" => ResourceValue::Sub(vec![
+                ResourceValue::String("${Tag}-FrontendDistributedCacheTrafficImbalanceAlarm".into()),
+                ResourceValue::Object(map!{
+                    "Tag" =>  ResourceValue::Ref("AWS::Region".into())
+                })
+            ]),
+            "ComparisonOperator" => ResourceValue::String("GreaterThanOrEqualToThreshold"),
+            "Threshold" => ResourceValue::Double(3.5)
+        },
+    };
+    assert_resource_equal(a, resource);
+}
+
 fn assert_resource_equal(val: Value, resource: ResourceParseTree) {
     let obj = val.as_object().unwrap();
     let resources = build_resources(obj).unwrap();


### PR DESCRIPTION
**What is the problem?**

As is noctilucent is unable to convert a CFN template if there exists floats in the template. I ran into this on the Threshold property for a CloudWatch alarm, but looking at the specification, there are a couple different resources that could run into this (any property that allows a Double)

**What is the solution?**

While parsing, we will check if a string is an integer or not, using https://docs.rs/numberkit/latest/numberkit/fn.is_digit.html. If it is we will continue with today's parsing, otherwise we will use a new ResourceValue::Double. The not straightforward thing that I had to do was create essentially a wrapper around the f64 type as it does not implement Eq. 

**Example error**

when trying to convert the following resource:

```
    "AlarmResource": {
      "DependsOn": "OtherResource",
      "Properties": {
        "AlarmDescription": "blah",
        "AlarmName": "blah",
        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
        "EvaluationPeriods": 3,
        (... Other Metadata ...)
        "Threshold": 3.5,
        "TreatMissingData": "breaching"
      },
      "Type": "AWS::CloudWatch::Alarm"
    },
```

I get the following error:

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/parser/resource.rs:152:72
stack backtrace:
   0: rust_begin_unwind
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/panicking.rs:143:14
   2: core::panicking::panic
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/panicking.rs:48:5
   3: noctilucent::parser::resource::build_resources_recursively
   4: noctilucent::parser::resource::build_resources
   5: noctilucent::CloudformationParseTree::build
   6: noctilucent::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

**After this change**

I am able to get the stack converted 💯 
(Generated typescript:

```
const alarmResource = new cloudwatch.CfnAlarm(this, 'AlarmResource', {
evaluationPeriods: 3,
threshold: 3.5,
alarmDescription: 'blah',
comparisonOperator: 'GreaterThanOrEqualToThreshold',
treatMissingData: 'breaching',
alarmName: `blah`
});
alarmResource.addOverride('DependsOn', ['OtherResource']);
```

(Disclaimer: I've never written rust before so let me know if there is a better way to do this)