### PR TITLE
Add support to define and use mappings that return numbers as the mapped value

### DIFF
--- a/src/ir/resources.rs
+++ b/src/ir/resources.rs
@@ -239,7 +239,6 @@ pub fn translate_resource(
             if let Complexity::Simple(simple_type) = &resource_translator.complexity {
                 return match simple_type {
                     SimpleType::Boolean => Ok(ResourceIr::Bool(s.parse().unwrap())),
-                    SimpleType::Integer => Ok(ResourceIr::Number(s.parse().unwrap())),
                     &_ => Ok(ResourceIr::String(s.to_string())),
                 };
             }

--- a/src/synthesizer/typescript_synthesizer.rs
+++ b/src/synthesizer/typescript_synthesizer.rs
@@ -57,6 +57,7 @@ impl TypescriptSynthesizer {
         for mapping in ir.mappings.iter() {
             let record_type = match mapping.find_first_type() {
                 MappingInnerValue::String(_) => "Record<string, Record<string, string>>",
+                MappingInnerValue::Number(_) => "Record<string, Record<string, number>>",
                 MappingInnerValue::List(_) => "Record<string, Record<string, Array<string>>>",
             };
 


### PR DESCRIPTION
**What is the problem?**

We are unable to handle mappings that have values that are supposed to be numbers. This is because we only support string or lists. This leads to translation failures when "FindInMap" outputs are expected to be an Integer or Double type but we end up returning strings.

**Example error**

when trying to convert a template like:

```
{
  "AWSTemplateFormatVersion": "2010-09-09",
  "Mappings": {
    "FleetValues": {
      "DistributedCacheNodeCount": {
        "beta": 1,
        "dev": 1,
        "large": 13,
        "medium": 13,
        "small": 13,
        "xlarge": 13
      }
    }
  },
  "Resources": {
    "FrontendDistributedCacheCluster": {
      "Metadata": {
        "Comments": "https://tt.amazon.com/0046181352 (post-service-split cache cluster)"
      },
      "Properties": {
        "AZMode": "some-az-mode"
        "CacheNodeType": "some-instance-type",
        "CacheParameterGroupName": "some group name",
        "CacheSubnetGroupName": "some-grou-name",
        "Engine": "memcached",
        "EngineVersion": "version",
        "NumCacheNodes": {
          "Fn::FindInMap": [
            "FleetValues",
            "DistributedCacheNodeCount",
            "beta"
          ]
        },
        "VpcSecurityGroupIds": [
          {
            "Fn::ImportValue": "CacheSG"
          }
        ]
      },
      "Type": "AWS::ElastiCache::CacheCluster"
    },
  }
}
```

I ran into the following error (added some prints to see where the translating was failing):

```
translating String("FleetValues") -- String("DistributedCacheNodeCount") -- String("beta")
translate_resource: String("FleetValues") -- "FleetValues" -- Simple(Integer)
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ParseIntError { kind: InvalidDigit }', src/ir/resources.rs:243:76
stack backtrace:
   0: rust_begin_unwind
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/panicking.rs:143:14
   2: core::result::unwrap_failed
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/result.rs:1749:5
   3: noctilucent::ir::resources::translate_resource
   4: noctilucent::ir::resources::translate_resource
   5: noctilucent::ir::resources::translates_resources
   6: noctilucent::ir::CloudformationProgramIr::new_from_parse_tree
   7: noctilucent::main
```

**Why is this happening?**

So we are trying to translate NumCacheNodes. Based on the spec, the value is supposed to be an integer. 

```
"NumCacheNodes": {
          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-cache-cluster.html#cfn-elasticache-cachecluster-numcachenodes",
          "PrimitiveType": "Integer",
          "Required": true,
          "UpdateType": "Conditional"
        },
```

However, in the FindInMap resource this is treated as a string and so we're unable to parse. What let me cross this error was changing the spec to make the PrimitiveType a "double". (What this lets us do is translate it as a string here and rely on the mapping value to ensure the type is correct)
The above is obviously something we can't do in real life though. So we just won't try to translate it as an integer here. However what that means is the parsing and translation will end up turning the value for numCacheNodes into a string type, this will end up leading to a compilation error.

**What is the solution?**

When parsing mappings we will allow for values to be represented as a number. Then during translation we can blanket treat everything as a string and rely on the "find in map" functionality to get the appropriate type. 

Ran the following commands:

```
cargo build --release
cargo fmt
cargo clippy
cargo test
```

Converted above template and generated the following typescript:

```
const fleetValues: Record<string, Record<string, number>> = {
			'DistributedCacheNodeCount': {
				'xlarge': 13,
				'small': 13,
				'beta': 1,
				'dev': 1,
				'large': 13,
				'medium': 13
			}
		};

const frontendDistributedCacheCluster = new elasticache.CfnCacheCluster(this, 'FrontendDistributedCacheCluster', {
engineVersion: 'version',
cacheSubnetGroupName: 'some-grou-name',
cacheNodeType: 'instance-type',
vpcSecurityGroupIds: [
cdk.Fn.importValue('CacheSG')
],
numCacheNodes: fleetValues['DistributedCacheNodeCount']['beta'],
cacheParameterGroupName: 'some group name',
engine: 'memcached',
azMode: distributedCacheSingleAzMode ? 'single-az' : 'cross-az'
		});
frontendDistributedCacheCluster.addOverride('Metadata', 
{
Comments: 'https://tt.amazon.com/0046181352 (post-service-split cache cluster)'
}
);
```