### PR TITLE
Update lookup table to handle arbitrary types

### DIFF
--- a/src/ir/mappings.rs
+++ b/src/ir/mappings.rs
@@ -1,3 +1,4 @@
+use crate::ir::mappings::OutputType::{Complex, Consistent};
 use crate::parser::lookup_table::MappingInnerValue;
 use crate::CloudformationParseTree;
 use std::collections::HashMap;
@@ -7,11 +8,34 @@ pub struct MappingInstruction {
     pub map: HashMap<String, HashMap<String, MappingInnerValue>>,
 }
 
+/// When printing out to a file, sometimes there are non ordinal types in mappings.
+/// An example of this is something like:
+///    {
+///       "DisableScaleIn": true,
+///       "ScaleInCooldown": 10
+///    }
+///
+/// The above example has both a number and a bool. This is considered "Complex".
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum OutputType {
+    Consistent(MappingInnerValue),
+    Complex,
+}
+
 impl MappingInstruction {
-    pub fn find_first_type(&self) -> &MappingInnerValue {
+    pub fn output_type(&self) -> OutputType {
         let value = self.map.values().next().unwrap();
-        let inner_value = value.values().next().unwrap();
-        inner_value
+        let first_inner_value = value.values().next().unwrap();
+
+        for _outer_map in self.map.values() {
+            for inner_value in value.values() {
+                if std::mem::discriminant(inner_value) != std::mem::discriminant(first_inner_value)
+                {
+                    return Complex;
+                }
+            }
+        }
+        Consistent(first_inner_value.clone())
     }
 }
 pub fn translate(parse_tree: &CloudformationParseTree) -> Vec<MappingInstruction> {
@@ -24,4 +48,74 @@ pub fn translate(parse_tree: &CloudformationParseTree) -> Vec<MappingInstruction
         })
     }
     instructions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    macro_rules! map(
+    { $($key:expr => $value:expr),+ } => {
+        {
+            let mut m = ::std::collections::HashMap::new();
+            $(
+                m.insert($key.to_string(), $value);
+            )+
+            m
+        }
+     };
+    );
+
+    #[test]
+    fn test_mapping_consistent_string() {
+        let mapping = MappingInstruction {
+            name: "TableMappings".into(),
+            map: map! {
+                "Table" => map!{
+                    "Key" => MappingInnerValue::String("Value".into()),
+                    "Key2" => MappingInnerValue::String("Value2".into())
+                }
+            },
+        };
+
+        let actual_output = mapping.output_type();
+        let expected_output = OutputType::Consistent(MappingInnerValue::String("Value".into()));
+        // In the end, we only care if the output is Consistent(string), not the value that is used.
+        assert_eq!(
+            std::mem::discriminant(&expected_output),
+            std::mem::discriminant(&actual_output)
+        );
+    }
+
+    #[test]
+    fn test_mapping_consistent_bool() {
+        let mapping = MappingInstruction {
+            name: "TableMappings".into(),
+            map: map! {
+                "Table" => map!{
+                    "DisableScaleIn" => MappingInnerValue::Bool(true)
+                }
+            },
+        };
+
+        let actual_output = mapping.output_type();
+        let expected_output = OutputType::Consistent(MappingInnerValue::Bool(true));
+        assert_eq!(expected_output, actual_output);
+    }
+
+    #[test]
+    fn test_mapping_complex() {
+        let mapping = MappingInstruction {
+            name: "TableMappings".into(),
+            map: map! {
+                "Table" => map!{
+                    "DisableScaleIn" => MappingInnerValue::Bool(true),
+                    "Cooldown" => MappingInnerValue::Number(10)
+                }
+            },
+        };
+
+        let actual_output = mapping.output_type();
+        let expected_output = OutputType::Complex;
+        assert_eq!(expected_output, actual_output);
+    }
 }

--- a/src/ir/resources.rs
+++ b/src/ir/resources.rs
@@ -1,6 +1,7 @@
 use crate::ir::reference::{Origin, Reference};
 use crate::ir::sub::{sub_parse_tree, SubValue};
-use crate::parser::resource::{ResourceValue, WrapperF64};
+use crate::parser::resource::ResourceValue;
+use crate::primitives::WrapperF64;
 use crate::specification::{spec, Complexity, SimpleType, Specification};
 use crate::{CloudformationParseTree, TransmuteError};
 use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 pub mod integrations;
 pub mod ir;
 pub mod parser;
+pub mod primitives;
 pub mod specification;
 pub mod synthesizer;
 

--- a/src/parser/resource.rs
+++ b/src/parser/resource.rs
@@ -1,8 +1,8 @@
+use crate::primitives::WrapperF64;
 use crate::TransmuteError;
 use numberkit::is_digit;
 use serde_json::{Map, Value};
 use std::collections::HashMap;
-use std::{f64, fmt};
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum ResourceValue {
@@ -30,32 +30,6 @@ pub enum ResourceValue {
 }
 
 impl ResourceValue {}
-
-#[derive(Debug, Clone, Copy)]
-pub struct WrapperF64 {
-    num: f64,
-}
-
-impl WrapperF64 {
-    pub fn new(num: f64) -> WrapperF64 {
-        WrapperF64 { num }
-    }
-}
-
-impl PartialEq for WrapperF64 {
-    fn eq(&self, other: &Self) -> bool {
-        // It's equal if the diff is very small
-        (self.num - other.num).abs() < 0.0000001
-    }
-}
-
-impl fmt::Display for WrapperF64 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.num)
-    }
-}
-
-impl Eq for WrapperF64 {}
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct ResourceParseTree {
@@ -182,10 +156,8 @@ pub fn build_resources_recursively(
             if is_digit(n.to_string(), false) {
                 return Ok(ResourceValue::Number(n.as_i64().unwrap()));
             }
-            let val = WrapperF64 {
-                num: n.as_f64().unwrap(),
-            };
-            return Ok(ResourceValue::Double(val));
+            let v = WrapperF64::new(n.as_f64().unwrap());
+            return Ok(ResourceValue::Double(v));
         }
         Value::Array(arr) => {
             let mut v = Vec::new();

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -1,0 +1,34 @@
+/**
+ * Primitives are for things that can be outside the scope of parsing and IR and used heavily across both
+ * Generally, attempt to keep this section to a minimu
+ *
+ */
+use std::fmt;
+
+/// WrapperF64 exists because compraisons and outputs into typescripts are annoying with the
+/// default f64. Use this whenever referring to a floating point number in CFN standard.
+#[derive(Debug, Clone, Copy)]
+pub struct WrapperF64 {
+    num: f64,
+}
+
+impl WrapperF64 {
+    pub fn new(num: f64) -> WrapperF64 {
+        WrapperF64 { num }
+    }
+}
+
+impl PartialEq for WrapperF64 {
+    fn eq(&self, other: &Self) -> bool {
+        // It's equal if the diff is very small
+        (self.num - other.num).abs() < 0.0000001
+    }
+}
+
+impl fmt::Display for WrapperF64 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.num)
+    }
+}
+
+impl Eq for WrapperF64 {}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,5 @@
-use noctilucent::parser::resource::{
-    build_resources, ResourceParseTree, ResourceValue, WrapperF64,
-};
+use noctilucent::parser::resource::{build_resources, ResourceParseTree, ResourceValue};
+use noctilucent::primitives::WrapperF64;
 use serde_json::Value;
 
 macro_rules! map(


### PR DESCRIPTION
It turns out that cloudformation actually allows arbitrary types in Fn::Mappings. Within that, it's also not uniform types as well.

This update handles the arbitrary types for non-array-based inputs and will "opt out" for non-array-based complex structures with an `any` mode, leaving it up to the user to resolve that problem in typescript. Also, in order to reuse f64 types, moved WrapperF64 to a primitives folder that spans the gap of parser and ir.