### PR TITLE
Upgrade type structure for Fn::FindInMappings

### DIFF
--- a/src/ir/resources.rs
+++ b/src/ir/resources.rs
@@ -350,9 +350,11 @@ pub fn translate_resource(
             Ok(ResourceIr::Sub(r))
         }
         ResourceValue::FindInMap(mapper, first, second) => {
-            let mapper_str = translate_resource(mapper, resource_translator)?;
-            let first_str = translate_resource(first, resource_translator)?;
-            let second_str = translate_resource(second, resource_translator)?;
+            let mut rt = resource_translator.clone();
+            rt.complexity = Complexity::Simple(SimpleType::String);
+            let mapper_str = translate_resource(mapper, &rt)?;
+            let first_str = translate_resource(first, &rt)?;
+            let second_str = translate_resource(second, &rt)?;
             Ok(ResourceIr::Map(
                 Box::new(mapper_str),
                 Box::new(first_str),


### PR DESCRIPTION
When passing down types into an Fn::Mapping, I originally expected to continue passing down the types into deeply nested structures.

This actually doesn't make sense. As an example, let's take a look at ReadCapacityUnits in DDB:

```
"ReadCapacityUnits" : 3000
```

Simple. It requires an integer.

When reading this fun mutated version:

```
"ReadCapacityUnits": {"Fn::FindInMap": ["DDBValue", "Table"] }
```

or something or other. ReadCapacityUnits is indeed still requiring an integer, but FindInMap is not, it is requiring two input strings in an array. The original code would pass the complexity type from the parent (in this case RSU), but that is incorrect and so would not work for resolving anything other than strings in maps. In this newest iteration, Mappings will now only resolve strings. This may cause chaos down the road, but according to the spec, all mapping keys are strings, so I'll allow it for now.