### PR TITLE
Add yaml support for CFN templates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license-file = "LICENSE"
 clap = "3.0.0-beta.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.9"
 serde_with = {version = "2.0.0", features = ["json"]}
 numberkit = "0.1.0"
 nom = "7.0.0"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Noctilucent will take your json and output the equivalent typescript.
 ## User Guide
 ```
 cargo build --release
-./target/release/noctilucent <INPUT> <OUTPUT>
+./target/release/noctilucent [--input-format yaml] <INPUT> [OUTPUT]
 ```
+* `input-format` is an optional parameter to specify the input format of the CFN template (json|yaml). If not specified, json is defaulted.
 * `INPUT` is the input file path.
 * `OUTPUT` is the output file path; if not specified, output will be printed on your command line.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,11 +22,26 @@ fn main() {
                 .required(false)
                 .index(2),
         )
+        .arg(
+            Arg::new("inputFormat")
+                .help("Sets the input template format")
+                .short('f')
+                .long("input-format")
+                .required(false)
+                .value_parser(["json", "yaml"])
+                .default_value("json"),
+        )
         .get_matches();
 
     let txt_location: &str = matches.value_of("INPUT").unwrap();
     let contents = fs::read_to_string(txt_location).unwrap();
-    let value: Value = serde_json::from_str(contents.as_str()).unwrap();
+    let input_format: &str = matches.value_of("inputFormat").unwrap();
+    let value: Value;
+    if input_format.eq("json") {
+        value = serde_json::from_str(contents.as_str()).unwrap();
+    } else {
+        value = serde_yaml::from_str::<serde_json::Value>(contents.as_str()).unwrap();
+    }
 
     let cfn_tree = CloudformationParseTree::build(&value).unwrap();
     let ir = CloudformationProgramIr::new_from_parse_tree(&cfn_tree).unwrap();


### PR DESCRIPTION
Add an additional option to specify the file format of the CFN template in order to support yaml CFN templates.