### PR TITLE
Add output conditions and fixed resource reference

### DIFF
--- a/src/ir/outputs.rs
+++ b/src/ir/outputs.rs
@@ -6,6 +6,8 @@ pub struct OutputInstruction {
     pub name: String,
     pub export: Option<ResourceIr>,
     pub value: ResourceIr,
+    pub condition: Option<String>,
+    pub description: Option<String>,
 }
 
 pub fn translate(parse_tree: &CloudformationParseTree) -> Vec<OutputInstruction> {
@@ -19,6 +21,8 @@ pub fn translate(parse_tree: &CloudformationParseTree) -> Vec<OutputInstruction>
         };
 
         let value = translate_resource(&output.value, &resource_translator).unwrap();
+        let condition = output.condition.clone();
+        let description = output.description.clone();
         let mut export = Option::None;
         if let Some(x) = &output.export {
             export = Option::Some(translate_resource(x, &resource_translator).unwrap());
@@ -28,6 +32,8 @@ pub fn translate(parse_tree: &CloudformationParseTree) -> Vec<OutputInstruction>
             name: name.to_string(),
             export,
             value,
+            condition,
+            description,
         })
     }
     instructions

--- a/src/parser/output.rs
+++ b/src/parser/output.rs
@@ -26,14 +26,24 @@ pub struct Output {
     pub logical_name: String,
     pub value: ResourceValue, // TODO - I think this is limited, may want to make it an enum.
     pub export: Option<ResourceValue>,
+    pub condition: Option<String>,
+    pub description: Option<String>,
 }
 
 impl Output {
-    fn new(logical_name: String, value: ResourceValue, export: Option<ResourceValue>) -> Output {
+    fn new(
+        logical_name: String,
+        value: ResourceValue,
+        export: Option<ResourceValue>,
+        condition: Option<String>,
+        description: Option<String>,
+    ) -> Output {
         Output {
             logical_name,
             value,
             export,
+            condition,
+            description,
         }
     }
 }
@@ -63,10 +73,22 @@ pub fn build_outputs(vals: &Map<String, Value>) -> Result<OutputsParseTree, Tran
             Some(x) => Option::Some(build_resources_recursively(logical_id, x)?),
         };
 
+        let condition = value
+            .get("Condition")
+            .and_then(|t| t.as_str())
+            .map(|t| t.to_string());
+
+        let description = value
+            .get("Description")
+            .and_then(|t| t.as_str())
+            .map(|t| t.to_string());
+
         outputs.add(Output {
             logical_name: logical_id.to_string(),
             value: val,
             export,
+            condition,
+            description,
         });
     }
 


### PR DESCRIPTION
- Added descriptions and condition handling for outputs. Now if an output has a condition, it will wrap the output in an if statement
```
"Output1":
    "Condition": "Condition1"
    "Description": "A CFN output"
    "Export":
      "Name":
        "Fn::Sub": "${AWS::StackName}-Output"
    "Value":
      "Ref": "SomeResource"
```

becomes
```
if (condition1) {
	new cdk.CfnOutput(this, 'Output1', {
		exportName: `${this.stackName}-Output`,
		description: 'A CFN output',
		value: someResource.ref
	});
}
```
- Modified resources so if the resource requires an if statement, the check for undefined occurs within the if statement. This fixes an issue where a resource is only set when a specific condition is true and is only reference in a resource when that condition is true, but the undefined check was happening outside the if statement, causing an error.
```
if (reference1 === undefined) { throw new Error(`A combination of conditions caused 'reference1' to be undefined. Fixit.`); }
let reference2;
if (condition1) {
	reference2 = new ec2.CfnBucket(this, 'Reference2', {
		routeTableId: cdk.Fn.importValue(`${props.partition}-Value`),
		subnetId: reference1.ref
	});
}
```
is now
```
let reference2;
if (condition1) {
	if (reference1 === undefined) { throw new Error(`A combination of conditions caused 'reference1' to be undefined. Fixit.`); }
	reference2 = new ec2.CfnBucket(this, 'Reference2', {
		routeTableId: cdk.Fn.importValue(`${props.partition}-Value`),
		subnetId: reference1.ref
	});
}
```
