### PR TITLE
Fixed using {} instead of undefined and to use Fn.select on Fn.getAZs

### DIFF
--- a/src/ir/outputs.rs
+++ b/src/ir/outputs.rs
@@ -6,6 +6,8 @@ pub struct OutputInstruction {
     pub name: String,
     pub export: Option<ResourceIr>,
     pub value: ResourceIr,
+    pub condition: Option<String>,
+    pub description: Option<String>,
 }
 
 pub fn translate(parse_tree: &CloudformationParseTree) -> Vec<OutputInstruction> {
@@ -19,6 +21,8 @@ pub fn translate(parse_tree: &CloudformationParseTree) -> Vec<OutputInstruction>
         };
 
         let value = translate_resource(&output.value, &resource_translator).unwrap();
+        let condition = output.condition.clone();
+        let description = output.description.clone();
         let mut export = Option::None;
         if let Some(x) = &output.export {
             export = Option::Some(translate_resource(x, &resource_translator).unwrap());
@@ -28,6 +32,8 @@ pub fn translate(parse_tree: &CloudformationParseTree) -> Vec<OutputInstruction>
             name: name.to_string(),
             export,
             value,
+            condition,
+            description,
         })
     }
     instructions

--- a/src/parser/output.rs
+++ b/src/parser/output.rs
@@ -26,14 +26,24 @@ pub struct Output {
     pub logical_name: String,
     pub value: ResourceValue, // TODO - I think this is limited, may want to make it an enum.
     pub export: Option<ResourceValue>,
+    pub condition: Option<String>,
+    pub description: Option<String>,
 }
 
 impl Output {
-    fn new(logical_name: String, value: ResourceValue, export: Option<ResourceValue>) -> Output {
+    fn new(
+        logical_name: String,
+        value: ResourceValue,
+        export: Option<ResourceValue>,
+        condition: Option<String>,
+        description: Option<String>,
+    ) -> Output {
         Output {
             logical_name,
             value,
             export,
+            condition,
+            description,
         }
     }
 }
@@ -63,10 +73,22 @@ pub fn build_outputs(vals: &Map<String, Value>) -> Result<OutputsParseTree, Tran
             Some(x) => Option::Some(build_resources_recursively(logical_id, x)?),
         };
 
+        let condition = value
+            .get("Condition")
+            .and_then(|t| t.as_str())
+            .map(|t| t.to_string());
+
+        let description = value
+            .get("Description")
+            .and_then(|t| t.as_str())
+            .map(|t| t.to_string());
+
         outputs.add(Output {
             logical_name: logical_id.to_string(),
             value: val,
             export,
+            condition,
+            description,
         });
     }
 

--- a/src/synthesizer/typescript_synthesizer.rs
+++ b/src/synthesizer/typescript_synthesizer.rs
@@ -374,7 +374,7 @@ pub fn to_string_ir(resource_value: &ResourceIr) -> Option<String> {
         ResourceIr::If(bool_expr, true_expr, false_expr) => {
             let bool_expr = pretty_name(bool_expr);
             let true_expr = match to_string_ir(true_expr) {
-                None => String::from("{}"),
+                None => String::from("undefined"),
                 Some(x) => x,
             };
             let false_expr = match to_string_ir(false_expr) {

--- a/src/synthesizer/typescript_synthesizer.rs
+++ b/src/synthesizer/typescript_synthesizer.rs
@@ -417,7 +417,12 @@ pub fn to_string_ir(resource_value: &ResourceIr) -> Option<String> {
         }
         ResourceIr::Select(index, obj) => {
             let str = to_string_ir(obj.as_ref()).unwrap();
-            Option::Some(format!("{}[{}]", str, *index))
+            match obj as &ResourceIr {
+                ResourceIr::GetAZs(_) => {
+                    Option::Some(format!("cdk.Fn.select({}, {})", *index, str))
+                }
+                _ => Option::Some(format!("{}[{}]", str, *index)),
+            }
         }
         ResourceIr::Cidr(ip_block, count, cidr_bits) => {
             let ip_block_str = to_string_ir(ip_block.as_ref()).unwrap();


### PR DESCRIPTION
- Using {} in the if statement does not compile and needs to be undefined.
- CDK build will fail when using [] on Fn.GetAzs as it's a token and requires Fn.Select when selecting on it.