### PR TITLE
(fix): Sub variables only saw References

### DIFF
--- a/src/ir/resources.rs
+++ b/src/ir/resources.rs
@@ -532,10 +532,7 @@ pub fn translate_resource(
                 .map(|x| match &x {
                     SubValue::String(x) => ResourceIr::String(x.to_string()),
                     SubValue::Variable(x) => match excess_map.get(x) {
-                        None => {
-                            // if x has a period, it is actually a get-attr
-                            ResourceIr::Ref(find_ref(x, resource_translator.parse_tree))
-                        }
+                        None => ResourceIr::Ref(find_ref(x, resource_translator.parse_tree)),
                         Some(x) => x.clone(),
                     },
                 })
@@ -668,6 +665,7 @@ fn find_ref(x: &str, parse_tree: &CloudformationParseTree) -> Reference {
         }
     }
 
+    // if x has a period, it is actually a get-attr
     if x.contains('.') {
         let splits = x.split('.');
         let sp: Vec<&str> = splits.collect();

--- a/src/synthesizer/typescript_synthesizer.rs
+++ b/src/synthesizer/typescript_synthesizer.rs
@@ -354,11 +354,19 @@ pub fn to_string_ir(resource_value: &ResourceIr) -> Option<String> {
             let mut r = Vec::new();
             for i in arr.iter() {
                 match i {
-                    ResourceIr::String(s) => r.push(s.to_string()),
+                    ResourceIr::String(s) => {
+                        // Since we are changing the output strings to use ticks for typescript sugar syntax,
+                        // we need to escape the ticks that already exist.
+                        let _replaced = s.replace('`', "\\`");
+                        let _replaced = s.replace('{', "\\{`");
+                        let replaced = s.replace('}', "\\}`");
+                        r.push(replaced.to_string())
+                    }
                     &_ => r.push(format!("${{{}}}", to_string_ir(i).unwrap())),
                 };
             }
-            Option::Some(format!("`{}`", r.join("")))
+            let full_text = r.join("");
+            Option::Some(format!("`{full_text}`"))
         }
         ResourceIr::Map(mapper, first, second) => {
             let a: &ResourceIr = mapper.as_ref();


### PR DESCRIPTION
So, when the Sub parser goes through, you can get a blob like:

```
"Fn::Sub": "echo ${lol}"
```

which would transform lol into a variable, as it's surrounded by ${}. It turns out that CFN doesn't need a reference of any kind, and will just output the string inside if it doesn't match any origin. Meanwhile, my system would attempt to topological sort `lol` off a Logical Id, but not find a Logical Id! So it would crash.

There were a few other bugs in this patch (escaping ticks, simplify the parser) that aren't worth mentioning.