### PR TITLE
chore: remove dependency on `serde_json`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,8 @@ license-file = "LICENSE"
 [dependencies]
 clap = "3.0.0-beta.2"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 serde_yaml = "0.9"
-serde_with = {version = "2.0.0", features = ["json"]}
+serde_with = { version = "2.0.0", features = ["json"] }
 numberkit = "0.1.0"
 nom = "7.0.0"
 voca_rs = "1.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license-file = "LICENSE"
 clap = "3.0.0-beta.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
-serde_with = { version = "2.0.0", features = ["json"] }
+serde_with = "2.0.0"
 numberkit = "0.1.0"
 nom = "7.0.0"
 voca_rs = "1.14.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use crate::parser::lookup_table::{build_mappings, MappingsParseTree};
 use crate::parser::output::{build_outputs, OutputsParseTree};
 use crate::parser::parameters::{build_parameters, Parameters};
 use crate::parser::resource::{build_resources, ResourceValue, ResourcesParseTree};
-use serde_json::Value;
+use serde_yaml::Value;
 use std::collections::HashSet;
 
 pub mod integrations;
@@ -56,29 +56,29 @@ pub struct CloudformationParseTree {
 
 impl CloudformationParseTree {
     pub fn build(json_obj: &Value) -> Result<CloudformationParseTree, TransmuteError> {
-        let parameters = match json_obj["Parameters"].as_object() {
+        let parameters = match json_obj["Parameters"].as_mapping() {
             None => Parameters::new(),
             Some(params) => build_parameters(params)?,
         };
 
-        let conditions = match json_obj["Conditions"].as_object() {
+        let conditions = match json_obj["Conditions"].as_mapping() {
             None => ConditionsParseTree::new(),
             Some(x) => build_conditions(x)?,
         };
 
         // All stacks must have resources, so no checking.
-        let resources = build_resources(json_obj["Resources"].as_object().unwrap())?;
+        let resources = build_resources(json_obj["Resources"].as_mapping().unwrap())?;
 
         let mut logical_lookup = HashSet::new();
         for resource in resources.resources.iter() {
             logical_lookup.insert(resource.name.clone());
         }
 
-        let mappings = match json_obj["Mappings"].as_object() {
+        let mappings = match json_obj["Mappings"].as_mapping() {
             None => MappingsParseTree::new(),
             Some(x) => build_mappings(x)?,
         };
-        let outputs = match json_obj["Outputs"].as_object() {
+        let outputs = match json_obj["Outputs"].as_mapping() {
             None => OutputsParseTree::new(),
             Some(x) => build_outputs(x)?,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use noctilucent::ir::CloudformationProgramIr;
 use noctilucent::synthesizer::typescript_synthesizer::TypescriptSynthesizer;
 use noctilucent::synthesizer::Synthesizer;
 use noctilucent::CloudformationParseTree;
-use serde_json::Value;
+use serde_yaml::Value;
 use std::{fs, io};
 
 fn main() {
@@ -30,19 +30,19 @@ fn main() {
                 .long("input-format")
                 .required(false)
                 .value_parser(["json", "yaml"])
-                .default_value("json"),
+                .hide(true),
         )
         .get_matches();
 
+    if matches.is_present("inputFormat") {
+        eprintln!("--inputFormat (-f) is a no-op and will be removed in a future version. All input is treated as YAML");
+        eprintln!("as it is a strict super-set of JSON (all valid JSON is valid YAML).");
+    }
+
     let txt_location: &str = matches.value_of("INPUT").unwrap();
     let contents = fs::read_to_string(txt_location).unwrap();
-    let input_format: &str = matches.value_of("inputFormat").unwrap();
 
-    let value: Value = if input_format.eq("json") {
-        serde_json::from_str(contents.as_str()).unwrap()
-    } else {
-        serde_yaml::from_str::<Value>(contents.as_str()).unwrap()
-    };
+    let value: Value = serde_yaml::from_str::<Value>(contents.as_str()).unwrap();
 
     let cfn_tree = CloudformationParseTree::build(&value).unwrap();
     let ir = CloudformationProgramIr::new_from_parse_tree(&cfn_tree).unwrap();

--- a/src/parser/condition.rs
+++ b/src/parser/condition.rs
@@ -100,7 +100,7 @@ fn build_condition_recursively(name: &str, obj: &Value) -> Result<ConditionValue
     #[allow(clippy::never_loop)]
     for (condition_name, condition_object) in val.as_ref() {
         let cond: ConditionValue = match condition_name.as_str() {
-            Some("!And") | Some("Fn::And") => {
+            Some("!And" | "Fn::And") => {
                 let mut v: Vec<ConditionValue> = Vec::new();
                 let arr = match condition_object.as_sequence() {
                     None => {
@@ -117,7 +117,7 @@ fn build_condition_recursively(name: &str, obj: &Value) -> Result<ConditionValue
 
                 ConditionValue::And(v)
             }
-            Some("!Equals") | Some("Fn::Equals") => {
+            Some("!Equals" | "Fn::Equals") => {
                 let arr = match condition_object.as_sequence() {
                     None => {
                         return Err(TransmuteError {
@@ -145,7 +145,7 @@ fn build_condition_recursively(name: &str, obj: &Value) -> Result<ConditionValue
                 }?;
                 ConditionValue::Equals(Box::new(obj1), Box::new(obj2))
             }
-            Some("!Not") | Some("Fn::Not") => {
+            Some("!Not" | "Fn::Not") => {
                 let arr = match condition_object.as_sequence() {
                     None => {
                         return Err(TransmuteError {
@@ -165,7 +165,7 @@ fn build_condition_recursively(name: &str, obj: &Value) -> Result<ConditionValue
                 }?;
                 ConditionValue::Not(Box::new(obj1))
             }
-            Some("!Or") | Some("Fn::Or") => {
+            Some("!Or" | "Fn::Or") => {
                 let arr = match condition_object.as_sequence() {
                     None => {
                         return Err(TransmuteError {
@@ -183,7 +183,7 @@ fn build_condition_recursively(name: &str, obj: &Value) -> Result<ConditionValue
 
                 ConditionValue::Or(v)
             }
-            Some("Condition") => {
+            Some("!Condition" | "Condition") => {
                 let condition_name = match condition_object.as_str() {
                     None => {
                         return Err(TransmuteError {
@@ -194,7 +194,7 @@ fn build_condition_recursively(name: &str, obj: &Value) -> Result<ConditionValue
                 };
                 ConditionValue::Condition(condition_name.to_string())
             }
-            Some("Ref") => {
+            Some("!Ref" | "Ref") => {
                 let ref_name = match condition_object.as_str() {
                     None => {
                         return Err(TransmuteError {
@@ -205,7 +205,7 @@ fn build_condition_recursively(name: &str, obj: &Value) -> Result<ConditionValue
                 };
                 ConditionValue::Ref(ref_name.to_string())
             }
-            Some("!FindInMap") | Some("Fn::FindInMap") => {
+            Some("!FindInMap" | "Fn::FindInMap") => {
                 let arr = match condition_object.as_sequence() {
                     None => {
                         return Err(TransmuteError {

--- a/src/parser/output.rs
+++ b/src/parser/output.rs
@@ -1,6 +1,6 @@
 use crate::parser::resource::build_resources_recursively;
 use crate::{ResourceValue, TransmuteError};
-use serde_json::{Map, Value};
+use serde_yaml::Mapping;
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -54,9 +54,10 @@ impl Default for OutputsParseTree {
     }
 }
 
-pub fn build_outputs(vals: &Map<String, Value>) -> Result<OutputsParseTree, TransmuteError> {
+pub fn build_outputs(vals: &Mapping) -> Result<OutputsParseTree, TransmuteError> {
     let mut outputs = OutputsParseTree::new();
     for (logical_id, value) in vals.iter() {
+        let logical_id = logical_id.as_str().unwrap();
         let val = match value.get("Value") {
             None => {
                 // All outputs *MUST* have a value. Fail

--- a/src/parser/resource.rs
+++ b/src/parser/resource.rs
@@ -190,7 +190,7 @@ pub fn build_resources_recursively(
         #[allow(clippy::never_loop)]
         for (resource_name, resource_object) in val.as_ref() {
             let cond: ResourceValue = match resource_name.as_str() {
-                Some("!Sub") | Some("Fn::Sub") => {
+                Some("!Sub" | "Fn::Sub") => {
                     let mut v = Vec::new();
                     match resource_object {
                         Value::String(str) => {
@@ -212,7 +212,7 @@ pub fn build_resources_recursively(
                     }
                     ResourceValue::Sub(v)
                 }
-                Some("!FindInMap") | Some("Fn::FindInMap") => {
+                Some("!FindInMap" | "Fn::FindInMap") => {
                     let v = match resource_object.as_sequence() {
                         None => {
                             return Err(TransmuteError {
@@ -260,7 +260,7 @@ pub fn build_resources_recursively(
                         Box::new(third_obj),
                     )
                 }
-                Some("!GetAtt") | Some("Fn::GetAtt") => {
+                Some("!GetAtt" | "Fn::GetAtt") => {
                     match resource_object {
                         // Short form: "Fn::GetAttr": "blah.blah"
                         Value::String(x) => {
@@ -306,7 +306,7 @@ pub fn build_resources_recursively(
                         }
                     }
                 }
-                Some("!GetAZs") | Some("Fn::GetAZs") => {
+                Some("!GetAZs" | "Fn::GetAZs") => {
                     let v = match resource_object {
                         Value::String(_) => {
                             build_resources_recursively(name, resource_object)
@@ -327,15 +327,15 @@ pub fn build_resources_recursively(
                     ResourceValue::GetAZs(Box::new(v))
                 }
 
-                Some("!Base64") | Some("Fn::Base64") => {
+                Some("!Base64" | "Fn::Base64") => {
                     let resolved_obj = build_resources_recursively(name, resource_object)?;
                     ResourceValue::Base64(Box::new(resolved_obj))
                 }
-                Some("!ImportValue") | Some("Fn::ImportValue") => {
+                Some("!ImportValue" | "Fn::ImportValue") => {
                     let resolved_obj = build_resources_recursively(name, resource_object)?;
                     ResourceValue::ImportValue(Box::new(resolved_obj))
                 }
-                Some("!Select") | Some("Fn::Select") => {
+                Some("!Select" | "Fn::Select") => {
                     let arr = resource_object.as_sequence().unwrap();
 
                     let index = match arr.get(0) {
@@ -361,7 +361,7 @@ pub fn build_resources_recursively(
 
                     ResourceValue::Select(Box::new(index), Box::new(obj))
                 }
-                Some("!If") | Some("Fn::If") => {
+                Some("!If" | "Fn::If") => {
                     let v = match resource_object.as_sequence() {
                         None => {
                             return Err(TransmuteError {
@@ -407,7 +407,7 @@ pub fn build_resources_recursively(
                         Box::new(third_obj),
                     )
                 }
-                Some("!Join") | Some("Fn::Join") => {
+                Some("!Join" | "Fn::Join") => {
                     let arr = match resource_object.as_sequence() {
                         None => {
                             return Err(TransmuteError {
@@ -428,7 +428,7 @@ pub fn build_resources_recursively(
 
                     ResourceValue::Join(v)
                 }
-                Some("!Cidr") | Some("Fn::Cidr") => {
+                Some("!Cidr" | "Fn::Cidr") => {
                     let v = match resource_object.as_sequence() {
                         None => {
                             return Err(TransmuteError {
@@ -477,7 +477,7 @@ pub fn build_resources_recursively(
                         Box::new(third_obj),
                     )
                 }
-                Some("Ref") => {
+                Some("!Ref" | "Ref") => {
                     let ref_name = match resource_object.as_str() {
                         None => {
                             return Err(TransmuteError {

--- a/src/specification/mod.rs
+++ b/src/specification/mod.rs
@@ -1,6 +1,6 @@
 use crate::specification::Structure::{Composite, Simple};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_yaml::Value;
 use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -126,9 +126,9 @@ pub struct Specification {
 impl Specification {
     pub fn new() -> Specification {
         let str = include_str!("spec.json");
-        let raw = serde_json::from_str::<RawSpecification>(str).unwrap();
-        let compressed_str = serde_json::to_string::<RawSpecification>(&raw).unwrap();
-        serde_json::from_str::<Specification>(&compressed_str).unwrap()
+        let raw = serde_yaml::from_str::<RawSpecification>(str).unwrap();
+        let compressed_str = serde_yaml::to_string::<RawSpecification>(&raw).unwrap();
+        serde_yaml::from_str::<Specification>(&compressed_str).unwrap()
     }
 
     // Resource Properties in Specification look something like:

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1,0 +1,235 @@
+/// Shamelessly copied from: https://docs.rs/serde_json/latest/src/serde_json/macros.rs.html
+
+#[macro_export]
+macro_rules! json {
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an array [...]. Produces a vec![...]
+    // of the elements.
+    //
+    // Must be invoked as: json!(@array [] $($tt)*)
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done with trailing comma.
+    (@array [$($elems:expr,)*]) => {
+        json_internal_vec![$($elems,)*]
+    };
+
+    // Done without trailing comma.
+    (@array [$($elems:expr),*]) => {
+        json_internal_vec![$($elems),*]
+    };
+
+    // Next element is `null`.
+    (@array [$($elems:expr,)*] null $($rest:tt)*) => {
+        json!(@array [$($elems,)* json!(null)] $($rest)*)
+    };
+
+    // Next element is `true`.
+    (@array [$($elems:expr,)*] true $($rest:tt)*) => {
+        json!(@array [$($elems,)* json!(true)] $($rest)*)
+    };
+
+    // Next element is `false`.
+    (@array [$($elems:expr,)*] false $($rest:tt)*) => {
+        json!(@array [$($elems,)* json!(false)] $($rest)*)
+    };
+
+    // Next element is an array.
+    (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
+        json!(@array [$($elems,)* json!([$($array)*])] $($rest)*)
+    };
+
+    // Next element is a map.
+    (@array [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
+        json!(@array [$($elems,)* json!({$($map)*})] $($rest)*)
+    };
+
+    // Next element is an expression followed by comma.
+    (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
+        json!(@array [$($elems,)* json!($next),] $($rest)*)
+    };
+
+    // Last element is an expression with no trailing comma.
+    (@array [$($elems:expr,)*] $last:expr) => {
+        json!(@array [$($elems,)* json!($last)])
+    };
+
+    // Comma after the most recent element.
+    (@array [$($elems:expr),*] , $($rest:tt)*) => {
+        json!(@array [$($elems,)*] $($rest)*)
+    };
+
+    // Unexpected token after most recent element.
+    (@array [$($elems:expr),*] $unexpected:tt $($rest:tt)*) => {
+        json_unexpected!($unexpected)
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an object {...}. Each entry is
+    // inserted into the given map variable.
+    //
+    // Must be invoked as: json!(@object $map () ($($tt)*) ($($tt)*))
+    //
+    // We require two copies of the input tokens so that we can match on one
+    // copy and trigger errors on the other copy.
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done.
+    (@object $object:ident () () ()) => {};
+
+    // Insert the current entry followed by trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+        json!(@object $object () ($($rest)*) ($($rest)*));
+    };
+
+    // Current entry followed by unexpected token.
+    (@object $object:ident [$($key:tt)+] ($value:expr) $unexpected:tt $($rest:tt)*) => {
+        json_unexpected!($unexpected);
+    };
+
+    // Insert the last entry without trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr)) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+    };
+
+    // Next value is `null`.
+    (@object $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
+        json!(@object $object [$($key)+] (json!(null)) $($rest)*);
+    };
+
+    // Next value is `true`.
+    (@object $object:ident ($($key:tt)+) (: true $($rest:tt)*) $copy:tt) => {
+        json!(@object $object [$($key)+] (json!(true)) $($rest)*);
+    };
+
+    // Next value is `false`.
+    (@object $object:ident ($($key:tt)+) (: false $($rest:tt)*) $copy:tt) => {
+        json!(@object $object [$($key)+] (json!(false)) $($rest)*);
+    };
+
+    // Next value is an array.
+    (@object $object:ident ($($key:tt)+) (: [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
+        json!(@object $object [$($key)+] (json!([$($array)*])) $($rest)*);
+    };
+
+    // Next value is a map.
+    (@object $object:ident ($($key:tt)+) (: {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
+        json!(@object $object [$($key)+] (json!({$($map)*})) $($rest)*);
+    };
+
+    // Next value is an expression followed by comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr , $($rest:tt)*) $copy:tt) => {
+        json!(@object $object [$($key)+] (json!($value)) , $($rest)*);
+    };
+
+    // Last value is an expression with no trailing comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr) $copy:tt) => {
+        json!(@object $object [$($key)+] (json!($value)));
+    };
+
+    // Missing value for last entry. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)+) (:) $copy:tt) => {
+        // "unexpected end of macro invocation"
+        json!();
+    };
+
+    // Missing colon and value for last entry. Trigger a reasonable error
+    // message.
+    (@object $object:ident ($($key:tt)+) () $copy:tt) => {
+        // "unexpected end of macro invocation"
+        json!();
+    };
+
+    // Misplaced colon. Trigger a reasonable error message.
+    (@object $object:ident () (: $($rest:tt)*) ($colon:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `:`".
+        json_unexpected!($colon);
+    };
+
+    // Found a comma inside a key. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)*) (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `,`".
+        json_unexpected!($comma);
+    };
+
+    // Key is fully parenthesized. This avoids clippy double_parens false
+    // positives because the parenthesization may be necessary here.
+    (@object $object:ident () (($key:expr) : $($rest:tt)*) $copy:tt) => {
+        json!(@object $object ($key) (: $($rest)*) (: $($rest)*));
+    };
+
+    // Refuse to absorb colon token into key expression.
+    (@object $object:ident ($($key:tt)*) (: $($unexpected:tt)+) $copy:tt) => {
+        json_expect_expr_comma!($($unexpected)+);
+    };
+
+    // Munch a token into the current key.
+    (@object $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
+        json!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // The main implementation.
+    //
+    // Must be invoked as: json!($($json)+)
+    //////////////////////////////////////////////////////////////////////////
+
+    (null) => {
+        serde_yaml::Value::Null
+    };
+
+    (true) => {
+        serde_yaml::Value::Bool(true)
+    };
+
+    (false) => {
+        serde_yaml::Value::Bool(false)
+    };
+
+    ([]) => {
+        serde_yaml::Value::Array(json_internal_vec![])
+    };
+
+    ([ $($tt:tt)+ ]) => {
+        serde_yaml::Value::Sequence(json!(@array [] $($tt)+))
+    };
+
+    ({}) => {
+        serde_yaml::Value::Object(serde_yaml::Mapping::new())
+    };
+
+    ({ $($tt:tt)+ }) => {
+        serde_yaml::Value::Mapping({
+            let mut object = serde_yaml::Mapping::new();
+            json!(@object object () ($($tt)+) ($($tt)+));
+            object
+        })
+    };
+
+    // Any Serialize type: numbers, strings, struct literals, variables etc.
+    // Must be below every other rule.
+    ($other:expr) => {
+        serde_yaml::to_value(&$other).unwrap()
+    };
+}
+
+// The json_internal macro above cannot invoke vec directly because it uses
+// local_inner_macros. A vec invocation there would resolve to serde_yaml::vec.
+// Instead invoke vec here outside of local_inner_macros.
+#[macro_export]
+macro_rules! json_internal_vec {
+    ($($content:tt)*) => {
+        vec![$($content)*]
+    };
+}
+
+#[macro_export]
+macro_rules! json_unexpected {
+    () => {};
+}
+
+#[macro_export]
+macro_rules! json_expect_expr_comma {
+    ($e:expr , $($tt:tt)*) => {};
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,8 @@
 use noctilucent::parser::resource::{build_resources, ResourceParseTree, ResourceValue};
 use noctilucent::primitives::WrapperF64;
-use serde_json::Value;
+use serde_yaml::Value;
+
+mod json;
 
 macro_rules! map(
     { $($key:expr => $value:expr),+ } => {
@@ -16,7 +18,7 @@ macro_rules! map(
 
 #[test]
 fn test_parse_tree_basics() {
-    let a = serde_json::json!({
+    let a = json!({
         "LogicalResource": {
             "Type": "AWS::IAM::Role",
             "Properties": {
@@ -50,7 +52,7 @@ fn test_parse_tree_basics() {
 
 #[test]
 fn test_basic_parse_tree_with_condition() {
-    let a: Value = serde_json::json!({
+    let a: Value = json!({
         "LogicalResource": {
             "Type": "AWS::IAM::Role",
             "Condition": "SomeCondition",
@@ -160,7 +162,7 @@ fn test_parse_tree_basics_with_deletion_policy() {
 
 #[test]
 fn test_parse_tree_sub_str() {
-    let a = serde_json::json!({
+    let a = json!({
         "LogicalResource": {
             "Type": "AWS::IAM::Role",
             "Properties": {
@@ -188,7 +190,7 @@ fn test_parse_tree_sub_str() {
 
 #[test]
 fn test_parse_tree_yaml_codes() {
-    let a = serde_json::json!({
+    let a = json!({
         "LogicalResource": {
             "Type": "AWS::IAM::Role",
             "Properties": {
@@ -215,7 +217,7 @@ fn test_parse_tree_yaml_codes() {
 }
 #[test]
 fn test_parse_get_attr_shorthand() {
-    let a = serde_json::json!({
+    let a = json!({
         "LogicalResource": {
             "Type": "AWS::IAM::Role",
             "Properties": {
@@ -243,7 +245,7 @@ fn test_parse_get_attr_shorthand() {
 
 #[test]
 fn test_parse_tree_sub_list() {
-    let a = serde_json::json!({
+    let a = json!({
         "LogicalResource": {
             "Type": "AWS::IAM::Role",
             "Properties": {
@@ -283,7 +285,7 @@ fn test_parse_tree_sub_list() {
 
 #[test]
 fn test_parse_tree_resource_with_floats() {
-    let a = serde_json::json!({
+    let a = json!({
         "Alarm": {
             "Type": "AWS::CloudWatch::Alarm",
             "Properties": {
@@ -326,7 +328,7 @@ fn test_parse_tree_resource_with_floats() {
 }
 
 fn assert_resource_equal(val: Value, resource: ResourceParseTree) {
-    let obj = val.as_object().unwrap();
+    let obj = val.as_mapping().unwrap();
     let resources = build_resources(obj).unwrap();
     assert_eq!(resources.resources[0], resource)
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -87,7 +87,7 @@ fn test_basic_parse_tree_with_condition() {
 
 #[test]
 fn test_basic_parse_tree_with_metadata() {
-    let a: Value = serde_json::json!({
+    let a: Value = json!({
         "LogicalResource": {
             "Type": "AWS::IAM::Role",
             "Metadata": {
@@ -126,7 +126,7 @@ fn test_basic_parse_tree_with_metadata() {
 
 #[test]
 fn test_parse_tree_basics_with_deletion_policy() {
-    let a: Value = serde_json::json!({
+    let a: Value = json!({
         "LogicalResource": {
             "Type": "AWS::IAM::Role",
             "DeletionPolicy": "Retain",


### PR DESCRIPTION
Since all valid JSON is also valid YAML, the `serde_yaml` library can be used to parse all kinds of input, without requiring user selection. Also changes the initial internal representation to be a YAML value instead of a JSON value, which is a little more expressive (although it's not clear whether this is a good thing in this particular case; but at least it reduces the dependency surface).