### PR TITLE
feat: add support for `Fn::Split`

### DIFF
--- a/src/synthesizer/typescript_synthesizer.rs
+++ b/src/synthesizer/typescript_synthesizer.rs
@@ -399,6 +399,10 @@ pub fn to_string_ir(resource_value: &ResourceIr) -> Option<String> {
 
             Option::Some(format!("{}.join('{}')", strs.join(","), sep.escape_debug()))
         }
+        ResourceIr::Split(sep, ir) => Option::Some(format!(
+            "cdk.Fn.split({sep:?}, {})",
+            to_string_ir(ir).unwrap()
+        )),
         ResourceIr::Ref(x) => Option::Some(x.synthesize()),
         ResourceIr::Base64(x) => {
             let str = to_string_ir(x.as_ref()).unwrap();


### PR DESCRIPTION
Added unit tests for parsing of all intrinsic functions as `ResourceValue` objects and added missing support for the `Fn::Split` instrinsic function.

Note that the `Fn::Transform` function is still unsupported, and neither are the `Fn::Length` and `Fn::ToJsonString` functions which require the `AWS::LanguageExtensions` transform to be used.