### PR TITLE
chore: add coverage gathering script

### DIFF
--- a/tasks/coverage.sh
+++ b/tasks/coverage.sh
@@ -1,0 +1,45 @@
+#/usr/bin/env bash
+set -euo pipefail
+
+COVERAGE_ROOT="${PWD}/target/coverage"
+
+rm -rf ${COVERAGE_ROOT}
+mkdir -p ${COVERAGE_ROOT}/profraw
+
+echo 'Running tests with coverage instrumentation...'
+
+CARGO_INCREMENTAL=0                                                             \
+RUSTFLAGS='-Cinstrument-coverage'                                               \
+LLVM_PROFILE_FILE="${COVERAGE_ROOT}/profraw/%p-%m.profraw"                      \
+cargo test
+
+if ! command -v grcov &>/dev/null; then
+  echo 'Installing grcov...'
+  cargo install grcov
+fi
+
+if ! rustup component list --installed | grep -e '^llvm-tools'; then
+  echo 'Installing the llvm-tools-preview rustup component...'
+  rustup component add llvm-tools-preview
+fi
+
+echo 'Generating coverage reports...'
+grcov "${COVERAGE_ROOT}/profraw"                                                \
+  --binary-path "${PWD}/target/debug/deps"                                      \
+  --source-dir "${PWD}"                                                         \
+  --output-types "html,lcov"                                                    \
+  --branch                                                                      \
+  --ignore-not-existing                                                         \
+  --keep-only "src/*"                                                           \
+  --ignore "src/main.rs"                                                        \
+  --output-path "${COVERAGE_ROOT}"                                              \
+  --commit-sha $(git rev-parse HEAD)                                            \
+  --service-name "noctilucent"
+
+# Rename `lcov` to a name that is aligned with what IDEs usually look for...
+mv "${COVERAGE_ROOT}/lcov" "${COVERAGE_ROOT}/lcov.info"
+
+echo 'Cleaning up...'
+rm -rf "${COVERAGE_ROOT}/profraw"
+
+echo 'All done!'

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -391,7 +391,7 @@ fn test_parse_simple_json_template() {
         mappings: MappingsParseTree::new(),
         conditions: ConditionsParseTree::new(),
         logical_lookup: CloudformationParseTree::build_logical_lookup(&resources),
-        resources: resources,
+        resources,
         outputs: OutputsParseTree::new(),
     };
 


### PR DESCRIPTION
You can run `./tasks/coverage.sh` and the coverage reports are produced under:
- HTML: `target/coverage/html`
- LCov: `target/coverage/lcov.info`

The `lcov` report is automatically picked up by VSCode's [Coverage Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) extension so developers can see coverage information in-line with the editor.