### PR TITLE
chore: Split out actions, use code coverage test

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -41,5 +41,12 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+          components: llvm-tools-preview
       - name: Tests with Coverage
         run: bash tasks/coverage.sh
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/coverage/lcov.info
+          fail_ci_if_error: true

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -5,8 +5,8 @@ on:
 name: Checks
 
 jobs:
-  correctness:
-    name: correctness
+  lint_and_format:
+    name: Lint and Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -17,11 +17,10 @@ jobs:
           override: true
           components: rustfmt, clippy
       # Ensure build.rs has ran before we assert formatting...
-      - name: Run tests
+      - name: Build
         uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --verbose
+          command: build
       - name: Check formatting
         uses: actions-rs/cargo@v1
         with:
@@ -32,3 +31,15 @@ jobs:
         with:
           command: clippy
           args: --manifest-path ./Cargo.toml -- -Adead-code -D warnings
+  testing:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Tests with Coverage
+        run: bash tasks/coverage.sh


### PR DESCRIPTION
Split out running tests and lint/format checks for cleaner understanding just looking at the review. Also update tests to run code coverage task.