### PR TITLE
chore: remove steps to parse CloudFormation templates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,6 @@ serde_with = "2.0.0"
 
 [profile.release]
 codegen-units = 1
-opt-level = 3
+incremental = false
 lto = true
+opt-level = 3

--- a/src/parser/condition.rs
+++ b/src/parser/condition.rs
@@ -3,7 +3,7 @@ use serde_yaml::{Mapping, Value};
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConditionValue {
     // Higher level boolean operators
     And(Vec<ConditionValue>),

--- a/src/parser/intrinsics.rs
+++ b/src/parser/intrinsics.rs
@@ -1,0 +1,214 @@
+use super::resource::ResourceValue;
+use serde::de::{Error, VariantAccess};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum IntrinsicFunction {
+    // Standard built-ins
+    Base64(ResourceValue),
+    Cidr {
+        ip_block: ResourceValue,
+        count: ResourceValue,
+        cidr_bits: ResourceValue,
+    },
+    FindInMap {
+        map_name: ResourceValue,
+        top_level_key: ResourceValue,
+        second_level_key: ResourceValue,
+    },
+    GetAtt {
+        logical_name: String,
+        attribute_name: String,
+    },
+    GetAZs(ResourceValue),
+    If {
+        condition_name: String,
+        value_if_true: ResourceValue,
+        value_if_false: ResourceValue,
+    },
+    ImportValue(ResourceValue),
+    Join {
+        sep: String,
+        list: ResourceValue,
+    },
+    Select {
+        index: ResourceValue,
+        list: ResourceValue,
+    },
+    Split {
+        sep: String,
+        string: ResourceValue,
+    },
+    Sub {
+        string: String,
+        replaces: Option<ResourceValue>,
+    },
+    Ref(String),
+
+    // Special semantics
+    Transform,
+
+    // Provided by the `AWS::LanguageExtensions` transform
+    Length,
+    ToJsonString,
+}
+
+static INTRINSIC_FUNCTION_TAGS: &[&str] = &[
+    "Base64",
+    "Cidr",
+    "FindInMap",
+    "GetAtt",
+    "GetAZs",
+    "ImportValue",
+    "Join",
+    "Select",
+    "Split",
+    "Sub",
+    "Ref",
+];
+
+impl IntrinsicFunction {
+    pub(super) fn from_enum<'de, A: serde::de::EnumAccess<'de>>(data: A) -> Result<Self, A::Error> {
+        let (tag, data): (String, _) = data.variant()?;
+
+        Ok(match tag.as_str() {
+            "Base64" => Self::Base64(data.newtype_variant()?),
+            "Cidr" => {
+                let (ip_block, count, cidr_bits) = data.newtype_variant()?;
+                Self::Cidr {
+                    ip_block,
+                    count,
+                    cidr_bits,
+                }
+            }
+            "FindInMap" => {
+                let (map_name, top_level_key, second_level_key) = data.newtype_variant()?;
+                Self::FindInMap {
+                    map_name,
+                    top_level_key,
+                    second_level_key,
+                }
+            }
+            "GetAtt" => {
+                let (logical_name, attribute_name) =
+                    data.newtype_variant::<StringOrPair>()?.into_pair()?;
+                Self::GetAtt {
+                    logical_name,
+                    attribute_name,
+                }
+            }
+            "GetAZs" => Self::GetAZs(data.newtype_variant()?),
+            "ImportValue" => Self::ImportValue(data.newtype_variant()?),
+            "Join" => {
+                let (sep, list) = data.newtype_variant()?;
+                Self::Join { sep, list }
+            }
+            "Select" => {
+                let (index, list) = data.newtype_variant()?;
+                Self::Select { index, list }
+            }
+            "Split" => {
+                let (sep, string) = data.newtype_variant()?;
+                Self::Split { sep, string }
+            }
+            "Sub" => {
+                let (string, replaces) = data.newtype_variant::<SubPayload>()?.into_pair();
+                Self::Sub { string, replaces }
+            }
+            "Ref" => Self::Ref(data.newtype_variant()?),
+            unknown => return Err(A::Error::unknown_variant(unknown, INTRINSIC_FUNCTION_TAGS)),
+        })
+    }
+
+    pub(super) fn from_singleton_map<'de, A: serde::de::MapAccess<'de>>(
+        key: &str,
+        data: &mut A,
+    ) -> Result<Option<Self>, A::Error> {
+        Ok(match key {
+            "!Base64" | "Fn::Base64" => Some(Self::Base64(data.next_value()?)),
+            "!Cidr" | "Fn::Cidr" => {
+                let (ip_block, count, cidr_bits) = data.next_value()?;
+                Some(Self::Cidr {
+                    ip_block,
+                    count,
+                    cidr_bits,
+                })
+            }
+            "!FindInMap" | "Fn::FindInMap" => {
+                let (map_name, top_level_key, second_level_key) = data.next_value()?;
+                Some(Self::FindInMap {
+                    map_name,
+                    top_level_key,
+                    second_level_key,
+                })
+            }
+            "!GetAtt" | "Fn::GetAtt" => {
+                let (logical_name, attribute_name) =
+                    data.next_value::<StringOrPair>()?.into_pair()?;
+                Some(Self::GetAtt {
+                    logical_name,
+                    attribute_name,
+                })
+            }
+            "!GetAZs" | "Fn::GetAZs" => Some(Self::GetAZs(data.next_value()?)),
+            "!ImportValue" | "Fn::ImportValue" => Some(Self::ImportValue(data.next_value()?)),
+            "!Join" | "Fn::Join" => {
+                let (sep, list) = data.next_value()?;
+                Some(Self::Join { sep, list })
+            }
+            "!Select" | "Fn::Select" => {
+                let (index, list) = data.next_value()?;
+                Some(Self::Select { index, list })
+            }
+            "!Split" | "Fn::Split" => {
+                let (sep, string) = data.next_value()?;
+                Some(Self::Split { sep, string })
+            }
+            "!Sub" | "Fn::Sub" => {
+                let (string, replaces) = data.next_value::<SubPayload>()?.into_pair();
+                Some(Self::Sub { string, replaces })
+            }
+            "!Ref" | "Ref" => Some(Self::Ref(data.next_value()?)),
+            _ => None,
+        })
+    }
+}
+
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum StringOrPair {
+    String(String),
+    Pair(String, String),
+}
+
+impl StringOrPair {
+    fn into_pair<E: serde::de::Error>(self) -> Result<(String, String), E> {
+        match self {
+            Self::String(string) => match string.split_once('.') {
+                Some((left, right)) => Ok((left.into(), right.into())),
+                None => Err(E::invalid_value(
+                    serde::de::Unexpected::Str(&string),
+                    &"<logicalNameOfResource>.<attributeName>",
+                )),
+            },
+            Self::Pair(left, right) => Ok((left, right)),
+        }
+    }
+}
+
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum SubPayload {
+    String(String),
+    SingletonList((String,)),
+    StringAndObject(String, ResourceValue),
+}
+
+impl SubPayload {
+    fn into_pair(self) -> (String, Option<ResourceValue>) {
+        match self {
+            Self::String(string) => (string, None),
+            Self::SingletonList((string,)) => (string, None),
+            Self::StringAndObject(string, object) => (string, Some(object)),
+        }
+    }
+}

--- a/src/parser/intrinsics.rs
+++ b/src/parser/intrinsics.rs
@@ -173,7 +173,7 @@ impl IntrinsicFunction {
     }
 }
 
-#[derive(serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[serde(untagged)]
 enum StringOrPair {
     String(String),
@@ -195,12 +195,12 @@ impl StringOrPair {
     }
 }
 
-#[derive(serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[serde(untagged)]
 enum SubPayload {
     String(String),
     SingletonList((String,)),
-    StringAndObject(String, ResourceValue),
+    StringAndObject(String, Option<ResourceValue>),
 }
 
 impl SubPayload {
@@ -208,7 +208,7 @@ impl SubPayload {
         match self {
             Self::String(string) => (string, None),
             Self::SingletonList((string,)) => (string, None),
-            Self::StringAndObject(string, object) => (string, Some(object)),
+            Self::StringAndObject(string, object) => (string, object),
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,4 +1,5 @@
 pub mod condition;
+mod intrinsics;
 pub mod lookup_table;
 pub mod output;
 pub mod parameters;

--- a/src/parser/output.rs
+++ b/src/parser/output.rs
@@ -1,4 +1,3 @@
-use crate::parser::resource::build_resources_recursively;
 use crate::{ResourceValue, TransmuteError};
 use serde_yaml::Mapping;
 use std::collections::HashMap;
@@ -65,13 +64,17 @@ pub fn build_outputs(vals: &Mapping) -> Result<OutputsParseTree, TransmuteError>
                     "All outputs must have a value, but this does not",
                 ));
             }
-            Some(x) => build_resources_recursively(logical_id, x)?,
+            Some(x) => serde_yaml::from_value(x.clone())
+                .map_err(|cause| TransmuteError::new(format!("{logical_id}: {cause}")))?,
         };
 
         // For all Exports that exist, it must have a Name object, if either don't exist, don't record.
         let export = match value.get("Export").and_then(|x| x.get("Name")) {
             None => Option::None,
-            Some(x) => Option::Some(build_resources_recursively(logical_id, x)?),
+            Some(x) => Option::Some(
+                serde_yaml::from_value(x.clone())
+                    .map_err(|cause| TransmuteError::new(format!("{logical_id}: {cause}")))?,
+            ),
         };
 
         let condition = value

--- a/src/parser/resource.rs
+++ b/src/parser/resource.rs
@@ -1,13 +1,15 @@
 use crate::primitives::WrapperF64;
 use crate::TransmuteError;
-use numberkit::is_digit;
+use serde::de::Error;
 use serde_yaml::{Mapping, Value};
-use std::borrow::Cow;
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::convert::TryInto;
 
-#[derive(Debug, Eq, PartialEq)]
+pub use super::intrinsics::IntrinsicFunction;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ResourceValue {
-    // Literally just json bits here
     Null,
     Bool(bool),
     Number(i64),
@@ -16,23 +18,128 @@ pub enum ResourceValue {
     Array(Vec<ResourceValue>),
     Object(HashMap<String, ResourceValue>),
 
-    /// Rest is meta functions
-    /// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html#w2ab1c33c28c21c29
-    Sub(Vec<ResourceValue>),
-    FindInMap(Box<ResourceValue>, Box<ResourceValue>, Box<ResourceValue>),
-    GetAtt(Box<ResourceValue>, Box<ResourceValue>),
-    GetAZs(Box<ResourceValue>),
-    If(Box<ResourceValue>, Box<ResourceValue>, Box<ResourceValue>),
-    Join(Vec<ResourceValue>),
-    Split(Box<ResourceValue>, Box<ResourceValue>),
-    Ref(String),
-    Base64(Box<ResourceValue>),
-    ImportValue(Box<ResourceValue>),
-    Select(Box<ResourceValue>, Box<ResourceValue>),
-    Cidr(Box<ResourceValue>, Box<ResourceValue>, Box<ResourceValue>),
+    IntrinsicFunction(Box<IntrinsicFunction>),
 }
 
-impl ResourceValue {}
+impl From<&str> for ResourceValue {
+    fn from(s: &str) -> Self {
+        ResourceValue::String(s.to_owned())
+    }
+}
+
+impl From<IntrinsicFunction> for ResourceValue {
+    fn from(i: IntrinsicFunction) -> Self {
+        match i {
+            IntrinsicFunction::Ref(ref_name) if ref_name == "AWS::NoValue" => ResourceValue::Null,
+            i => ResourceValue::IntrinsicFunction(Box::new(i)),
+        }
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ResourceValue {
+    fn deserialize<D: serde::de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ResourceValueVisitor;
+        impl<'de> serde::de::Visitor<'de> for ResourceValueVisitor {
+            type Value = ResourceValue;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a CloudFormation resource value")
+            }
+
+            fn visit_bool<E: serde::de::Error>(self, val: bool) -> Result<Self::Value, E> {
+                Ok(Self::Value::Bool(val))
+            }
+
+            fn visit_enum<A: serde::de::EnumAccess<'de>>(
+                self,
+                data: A,
+            ) -> Result<Self::Value, A::Error> {
+                IntrinsicFunction::from_enum(data).map(Into::into)
+            }
+
+            fn visit_f64<E: serde::de::Error>(self, val: f64) -> Result<Self::Value, E> {
+                Ok(Self::Value::Double(val.into()))
+            }
+
+            fn visit_i64<E: serde::de::Error>(self, val: i64) -> Result<Self::Value, E> {
+                Ok(Self::Value::Number(val))
+            }
+
+            fn visit_i128<E: serde::de::Error>(self, val: i128) -> Result<Self::Value, E> {
+                if let Ok(val) = val.try_into() {
+                    Ok(Self::Value::Number(val))
+                } else {
+                    Ok(Self::Value::Double(val.into()))
+                }
+            }
+
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut data: A,
+            ) -> Result<Self::Value, A::Error> {
+                let mut map = HashMap::with_capacity(data.size_hint().unwrap_or_default());
+                while let Some(key) = data.next_key::<String>()? {
+                    if let Some(intrinsic) = IntrinsicFunction::from_singleton_map(&key, &mut data)?
+                    {
+                        if let Some(extraneous) = data.next_key()? {
+                            return Err(A::Error::unknown_field(extraneous, &[]));
+                        }
+                        return Ok(intrinsic.into());
+                    }
+                    match map.entry(key) {
+                        Entry::Vacant(entry) => {
+                            entry.insert(data.next_value()?);
+                        }
+                        Entry::Occupied(entry) => {
+                            return Err(A::Error::custom(&format!(
+                                "duplicate object key {key:?}",
+                                key = entry.key()
+                            )))
+                        }
+                    }
+                }
+                Ok(Self::Value::Object(map))
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut data: A,
+            ) -> Result<Self::Value, A::Error> {
+                let mut vec = Vec::with_capacity(data.size_hint().unwrap_or_default());
+                while let Some(elem) = data.next_element()? {
+                    vec.push(elem);
+                }
+                Ok(Self::Value::Array(vec))
+            }
+
+            fn visit_str<E: serde::de::Error>(self, val: &str) -> Result<Self::Value, E> {
+                Ok(Self::Value::String(val.into()))
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, val: u64) -> Result<Self::Value, E> {
+                if let Ok(val) = val.try_into() {
+                    Ok(Self::Value::Number(val))
+                } else {
+                    Ok(Self::Value::Double(val.into()))
+                }
+            }
+
+            fn visit_u128<E: serde::de::Error>(self, val: u128) -> Result<Self::Value, E> {
+                if let Ok(val) = val.try_into() {
+                    Ok(Self::Value::Number(val))
+                } else {
+                    Ok(Self::Value::Double(val.into()))
+                }
+            }
+
+            fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+                Ok(Self::Value::Null)
+            }
+        }
+
+        deserializer.deserialize_any(ResourceValueVisitor)
+    }
+}
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct ResourceParseTree {
@@ -75,7 +182,8 @@ pub fn build_resources(resource_map: &Mapping) -> Result<ResourcesParseTree, Tra
         {
             for (prop_name, prop_value) in x {
                 let prop_name = prop_name.as_str().unwrap();
-                let result = build_resources_recursively(name, prop_value)?;
+                let result = serde_yaml::from_value(prop_value.clone())
+                    .map_err(|cause| TransmuteError::new(format!("{name}: {cause}")))?;
                 properties.insert(prop_name.to_owned(), result);
             }
         }
@@ -83,13 +191,19 @@ pub fn build_resources(resource_map: &Mapping) -> Result<ResourcesParseTree, Tra
         let metadata_obj = resource_object.get("Metadata");
         let mut metadata = Option::None;
         if let Some(x) = metadata_obj {
-            metadata = Option::Some(build_resources_recursively(name, x)?);
+            metadata = Option::Some(
+                serde_yaml::from_value(x.clone())
+                    .map_err(|cause| TransmuteError::new(format!("{name}: {cause}")))?,
+            );
         }
 
         let update_policy_obj = resource_object.get("UpdatePolicy");
         let mut update_policy = Option::None;
         if let Some(x) = update_policy_obj {
-            update_policy = Option::Some(build_resources_recursively(name, x)?);
+            update_policy = Option::Some(
+                serde_yaml::from_value(x.clone())
+                    .map_err(|cause| TransmuteError::new(format!("{name}: {cause}")))?,
+            );
         }
 
         let deletion_policy = resource_object
@@ -142,359 +256,6 @@ pub fn build_resources(resource_map: &Mapping) -> Result<ResourcesParseTree, Tra
     Ok(ResourcesParseTree { resources })
 }
 
-pub fn build_resources_recursively(
-    name: &str,
-    obj: &Value,
-) -> Result<ResourceValue, TransmuteError> {
-    let val: Cow<Mapping> = match obj {
-        Value::String(x) => return Ok(ResourceValue::String(x.to_string())),
-        Value::Null => return Ok(ResourceValue::Null),
-        Value::Bool(b) => return Ok(ResourceValue::Bool(b.to_owned())),
-        Value::Number(n) => {
-            if is_digit(n.to_string(), false) {
-                return Ok(ResourceValue::Number(n.as_i64().unwrap()));
-            }
-            let v = WrapperF64::new(n.as_f64().unwrap());
-            return Ok(ResourceValue::Double(v));
-        }
-        Value::Sequence(arr) => {
-            let mut v = Vec::new();
-            for item in arr.iter() {
-                let obj = build_resources_recursively(name, item)?;
-                v.push(obj);
-            }
-
-            return Ok(ResourceValue::Array(v));
-        }
-        // Only real follow-up object
-        Value::Mapping(x) => Cow::Borrowed(x),
-        Value::Tagged(x) => {
-            let mut mapping = Mapping::new();
-            mapping.insert(Value::String(x.tag.to_string()), x.value.clone());
-            Cow::Owned(mapping)
-        }
-    };
-
-    if val.len() > 1 || val.is_empty() {
-        let mut hm = HashMap::new();
-        for (name, obj) in val.as_ref() {
-            let name = name.as_str().unwrap();
-            hm.insert(name.to_owned(), build_resources_recursively(name, obj)?);
-        }
-
-        return Ok(ResourceValue::Object(hm));
-    } else {
-        #[allow(clippy::never_loop)]
-        for (resource_name, resource_object) in val.as_ref() {
-            let cond: ResourceValue = match resource_name.as_str() {
-                Some("!Sub" | "Fn::Sub") => {
-                    let mut v = Vec::new();
-                    match resource_object {
-                        Value::String(str) => {
-                            v.push(ResourceValue::String(str.to_owned()));
-                        }
-                        Value::Sequence(arr) => {
-                            for obj in arr.iter() {
-                                let resource = build_resources_recursively(name, obj)?;
-                                v.push(resource);
-                            }
-                        }
-                        _ => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::Sub can only be either an array or a string {name}"
-                            )));
-                        }
-                    }
-                    ResourceValue::Sub(v)
-                }
-                Some("!FindInMap" | "Fn::FindInMap") => {
-                    let v = match resource_object.as_sequence() {
-                        None => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::FindInMap is supposed to be an array entry {name}"
-                            )))
-                        }
-                        Some(x) => x,
-                    };
-
-                    let first_obj = match v.get(0) {
-                        None => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::FindInMap is supposed to have 3 values in array, has 0 {name}"
-                            )))
-                        }
-                        Some(x) => build_resources_recursively(name, x),
-                    }?;
-                    let second_obj = match v.get(1) {
-                        None => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::FindInMap is supposed to have 3 values in array, has 1 {name}"
-                            )))
-                        }
-                        Some(x) => build_resources_recursively(name, x),
-                    }?;
-                    let third_obj = match v.get(2) {
-                        None => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::FindInMap is supposed to have 3 values in array, has 2 {name}"
-                            )))
-                        }
-                        Some(x) => build_resources_recursively(name, x),
-                    }?;
-                    ResourceValue::FindInMap(
-                        Box::new(first_obj),
-                        Box::new(second_obj),
-                        Box::new(third_obj),
-                    )
-                }
-                Some("!GetAtt" | "Fn::GetAtt") => {
-                    match resource_object {
-                        // Short form: "Fn::GetAttr": "blah.blah"
-                        Value::String(x) => {
-                            let split_str: Vec<&str> = x.splitn(2, '.').collect();
-                            let resource_ref = split_str.first().unwrap();
-                            let attribute_ref = split_str.get(1).unwrap();
-
-                            ResourceValue::GetAtt(
-                                Box::new(ResourceValue::String(resource_ref.to_string())),
-                                Box::new(ResourceValue::String(attribute_ref.to_string())),
-                            )
-                        }
-                        Value::Sequence(v) => {
-                            let first_obj = match v.get(0) {
-                                None => {
-                                    return Err(TransmuteError::new(format!(
-                                            "Fn::GetAtt is supposed to have 3 values in array, has 0 {name}"
-                                        )))
-                                }
-                                Some(x) => build_resources_recursively(name, x),
-                            }?;
-                            let second_obj = match v.get(1) {
-                                None => {
-                                    return Err(TransmuteError::new(format!(
-                                            "Fn::GetAtt is supposed to have 3 values in array, has 1 {name}"
-                                        )))
-                                }
-                                Some(x) => build_resources_recursively(name, x),
-                            }?;
-
-                            ResourceValue::GetAtt(Box::new(first_obj), Box::new(second_obj))
-                        }
-                        &_ => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::GetAtt is supposed to be an array entry {name}"
-                            )))
-                        }
-                    }
-                }
-                Some("!GetAZs" | "Fn::GetAZs") => {
-                    let v = match resource_object {
-                        Value::String(_) => {
-                            build_resources_recursively(name, resource_object)
-                        }
-                        Value::Mapping(_) => {
-                            build_resources_recursively(name, resource_object)
-                        }
-                        x => {
-                            return Err(TransmuteError::new(format!(
-                                    "Fn::GetAZs only takes a string as input for resource {name} value: {x:?}"
-                                )))
-
-                        }
-                    }?;
-
-                    ResourceValue::GetAZs(Box::new(v))
-                }
-
-                Some("!Base64" | "Fn::Base64") => {
-                    let resolved_obj = build_resources_recursively(name, resource_object)?;
-                    ResourceValue::Base64(Box::new(resolved_obj))
-                }
-                Some("!ImportValue" | "Fn::ImportValue") => {
-                    let resolved_obj = build_resources_recursively(name, resource_object)?;
-                    ResourceValue::ImportValue(Box::new(resolved_obj))
-                }
-                Some("!Select" | "Fn::Select") => {
-                    let arr = resource_object.as_sequence().unwrap();
-
-                    let index = match arr.get(0) {
-                        None => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::Select is supposed to have 2 values in array, has 0 {name}"
-                            )))
-                        }
-                        Some(x) => build_resources_recursively(name, x),
-                    }?;
-                    let obj = match arr.get(1) {
-                        None => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::Select is supposed to have 2 values in array, has 1 {name}"
-                            )))
-                        }
-                        Some(x) => build_resources_recursively(name, x),
-                    }?;
-
-                    ResourceValue::Select(Box::new(index), Box::new(obj))
-                }
-                Some("!If" | "Fn::If") => {
-                    let v = match resource_object.as_sequence() {
-                        None => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::If is supposed to be an array entry {name}"
-                            )))
-                        }
-                        Some(x) => x,
-                    };
-
-                    let first_obj = match v.get(0) {
-                        None => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::If is supposed to have 3 values in array, has 0 {name}"
-                            )))
-                        }
-                        Some(x) => build_resources_recursively(name, x),
-                    }?;
-                    let second_obj = match v.get(1) {
-                        None => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::If is supposed to have 3 values in array, has 1 {name}"
-                            )))
-                        }
-                        Some(x) => build_resources_recursively(name, x),
-                    }?;
-                    let third_obj = match v.get(2) {
-                        None => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::If is supposed to have 3 values in array, has 2 {name}"
-                            )))
-                        }
-                        Some(x) => build_resources_recursively(name, x),
-                    }?;
-                    ResourceValue::If(
-                        Box::new(first_obj),
-                        Box::new(second_obj),
-                        Box::new(third_obj),
-                    )
-                }
-                Some("!Join" | "Fn::Join") => {
-                    let arr = match resource_object.as_sequence() {
-                        None => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::Join is supposed to be an array entry {name}"
-                            )))
-                        }
-                        Some(x) => x,
-                    };
-
-                    let mut v = Vec::new();
-
-                    for obj in arr.iter() {
-                        let resource = build_resources_recursively(name, obj)?;
-                        v.push(resource);
-                    }
-
-                    ResourceValue::Join(v)
-                }
-                Some("!Split" | "Fn::Split") => {
-                    let arr = match resource_object.as_sequence() {
-                        None => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::Split is supposed to be an array entry {name}"
-                            )))
-                        }
-                        Some(x) => x,
-                    };
-                    if arr.len() != 2 {
-                        return Err(TransmuteError::new(format!(
-                            "Fn::Split is supposed to have 2 values in array, has {len} {name}",
-                            len = arr.len()
-                        )));
-                    }
-                    let sep = build_resources_recursively(name, &arr[0])?;
-                    let val = build_resources_recursively(name, &arr[1])?;
-
-                    ResourceValue::Split(Box::new(sep), Box::new(val))
-                }
-                Some("!Cidr" | "Fn::Cidr") => {
-                    let v = match resource_object.as_sequence() {
-                        None => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::Cidr is supposed to be an array entry {name}"
-                            )))
-                        }
-                        Some(x) => x,
-                    };
-
-                    let first_obj = match v.get(0) {
-                        None => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::Cidr is supposed to have 3 values in array, has 0 {name}"
-                            )))
-                        }
-                        Some(x) => build_resources_recursively(name, x),
-                    }?;
-                    let second_obj = match v.get(1) {
-                        None => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::Cidr is supposed to have 3 values in array, has 1 {name}"
-                            )))
-                        }
-                        Some(x) => build_resources_recursively(name, x),
-                    }?;
-                    let third_obj = match v.get(2) {
-                        None => {
-                            return Err(TransmuteError::new(format!(
-                                "Fn::Cidr is supposed to have 3 values in array, has 2 {name}"
-                            )))
-                        }
-                        Some(x) => build_resources_recursively(name, x),
-                    }?;
-
-                    ResourceValue::Cidr(
-                        Box::new(first_obj),
-                        Box::new(second_obj),
-                        Box::new(third_obj),
-                    )
-                }
-                Some("!Ref" | "Ref") => {
-                    let ref_name = match resource_object.as_str() {
-                        None => {
-                            return Err(TransmuteError::new(format!(
-                                "Condition must a string {name}"
-                            )))
-                        }
-                        Some(x) => x,
-                    };
-
-                    match ref_name {
-                        "AWS::NoValue" => ResourceValue::Null,
-                        &_ => ResourceValue::Ref(ref_name.to_string()),
-                    }
-                }
-
-                // If it is none of the above, it must be part of the resource properties, continue
-                // parsing as if this was an object with a single property.
-                Some(v) => {
-                    let mut hm = HashMap::new();
-                    hm.insert(
-                        v.to_owned(),
-                        build_resources_recursively(name, resource_object)?,
-                    );
-                    ResourceValue::Object(hm)
-                }
-
-                None => unimplemented!("resource key is not a string"),
-            };
-
-            return Ok(cond);
-        }
-    }
-
-    Err(TransmuteError::new(format!(
-        "Could not find a parsable path for resource {name}, {obj:?}"
-    )))
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -506,16 +267,15 @@ mod test {
     fn intrinsic_base64() {
         const BASE64_TEXT: &str = "dGVzdAo=";
         assert_eq!(
-            ResourceValue::Base64(Box::new(ResourceValue::String(BASE64_TEXT.to_string()))),
-            build_resources_recursively("Dummy", &json!({ "Fn::Base64": BASE64_TEXT })).unwrap()
+            ResourceValue::from_value(json!({ "Fn::Base64": BASE64_TEXT })).unwrap(),
+            IntrinsicFunction::Base64(ResourceValue::String(BASE64_TEXT.to_string())).into(),
         );
         assert_eq!(
-            ResourceValue::Base64(Box::new(ResourceValue::String(BASE64_TEXT.to_string()))),
-            build_resources_recursively(
-                "Dummy",
-                &serde_yaml::from_str(&format!("!Base64 {BASE64_TEXT:?}")).unwrap()
+            ResourceValue::from_value(
+                serde_yaml::from_str(&format!("!Base64 {BASE64_TEXT:?}")).unwrap()
             )
-            .unwrap()
+            .unwrap(),
+            IntrinsicFunction::Base64(ResourceValue::String(BASE64_TEXT.to_string())).into(),
         );
     }
 
@@ -526,59 +286,56 @@ mod test {
         const CIDR_BITS: i64 = 8;
 
         assert_eq!(
-            ResourceValue::Cidr(
-                Box::new(ResourceValue::String(IP_BLOCK.to_string())),
-                Box::new(ResourceValue::Number(COUNT)),
-                Box::new(ResourceValue::Number(CIDR_BITS))
-            ),
-            build_resources_recursively(
-                "Dummy",
-                &json!({"Fn::Cidr": [IP_BLOCK, COUNT, CIDR_BITS] })
-            )
-            .unwrap()
+            ResourceValue::from_value(json!({"Fn::Cidr": [IP_BLOCK, COUNT, CIDR_BITS] })).unwrap(),
+            IntrinsicFunction::Cidr {
+                ip_block: ResourceValue::String(IP_BLOCK.to_string()),
+                count: ResourceValue::Number(COUNT),
+                cidr_bits: ResourceValue::Number(CIDR_BITS)
+            }
+            .into(),
         );
         assert_eq!(
-            ResourceValue::Cidr(
-                Box::new(ResourceValue::String(IP_BLOCK.to_string())),
-                Box::new(ResourceValue::Number(COUNT)),
-                Box::new(ResourceValue::Number(CIDR_BITS))
-            ),
-            build_resources_recursively(
-                "Dummy",
-                &serde_yaml::from_str(&format!("!Cidr [{IP_BLOCK:?}, {COUNT}, {CIDR_BITS}]"))
+            ResourceValue::from_value(
+                serde_yaml::from_str(&format!("!Cidr [{IP_BLOCK:?}, {COUNT}, {CIDR_BITS}]"))
                     .unwrap()
             )
-            .unwrap()
+            .unwrap(),
+            IntrinsicFunction::Cidr {
+                ip_block: ResourceValue::String(IP_BLOCK.to_string()),
+                count: ResourceValue::Number(COUNT),
+                cidr_bits: ResourceValue::Number(CIDR_BITS)
+            }
+            .into(),
         );
 
         assert_eq!(
-            ResourceValue::Cidr(
-                Box::new(ResourceValue::String(IP_BLOCK.to_string())),
-                Box::new(ResourceValue::String(COUNT.to_string())),
-                Box::new(ResourceValue::String(CIDR_BITS.to_string()))
-            ),
-            build_resources_recursively(
-                "Dummy",
-                &json!({"Fn::Cidr": [IP_BLOCK, COUNT.to_string(), CIDR_BITS.to_string()] })
+            ResourceValue::from_value(
+                json!({"Fn::Cidr": [IP_BLOCK, COUNT.to_string(), CIDR_BITS.to_string()] })
             )
-            .unwrap()
+            .unwrap(),
+            IntrinsicFunction::Cidr {
+                ip_block: ResourceValue::String(IP_BLOCK.to_string()),
+                count: ResourceValue::String(COUNT.to_string()),
+                cidr_bits: ResourceValue::String(CIDR_BITS.to_string())
+            }
+            .into(),
         );
         assert_eq!(
-            ResourceValue::Cidr(
-                Box::new(ResourceValue::String(IP_BLOCK.to_string())),
-                Box::new(ResourceValue::String(COUNT.to_string())),
-                Box::new(ResourceValue::String(CIDR_BITS.to_string()))
-            ),
-            build_resources_recursively(
-                "Dummy",
-                &serde_yaml::from_str(&format!(
+            ResourceValue::from_value(
+                serde_yaml::from_str(&format!(
                     "!Cidr [{IP_BLOCK:?}, {:?}, {:?}]",
                     COUNT.to_string(),
                     CIDR_BITS.to_string()
                 ))
                 .unwrap()
             )
-            .unwrap()
+            .unwrap(),
+            IntrinsicFunction::Cidr {
+                ip_block: ResourceValue::String(IP_BLOCK.to_string()),
+                count: ResourceValue::String(COUNT.to_string()),
+                cidr_bits: ResourceValue::String(CIDR_BITS.to_string())
+            }
+            .into(),
         );
     }
 
@@ -588,31 +345,29 @@ mod test {
         const FIRST_KEY: &str = "FirstKey";
         const SECOND_KEY: &str = "SecondKey";
         assert_eq!(
-            ResourceValue::FindInMap(
-                Box::new(ResourceValue::String(MAP_NAME.to_string())),
-                Box::new(ResourceValue::String(FIRST_KEY.to_string())),
-                Box::new(ResourceValue::String(SECOND_KEY.to_string()))
-            ),
-            build_resources_recursively(
-                "Dummy",
-                &json!({"Fn::FindInMap": [MAP_NAME, FIRST_KEY, SECOND_KEY]})
-            )
-            .unwrap()
+            ResourceValue::from_value(json!({"Fn::FindInMap": [MAP_NAME, FIRST_KEY, SECOND_KEY]}))
+                .unwrap(),
+            IntrinsicFunction::FindInMap {
+                map_name: ResourceValue::String(MAP_NAME.to_string()),
+                top_level_key: ResourceValue::String(FIRST_KEY.to_string()),
+                second_level_key: ResourceValue::String(SECOND_KEY.to_string())
+            }
+            .into(),
         );
         assert_eq!(
-            ResourceValue::FindInMap(
-                Box::new(ResourceValue::String(MAP_NAME.to_string())),
-                Box::new(ResourceValue::String(FIRST_KEY.to_string())),
-                Box::new(ResourceValue::String(SECOND_KEY.to_string()))
-            ),
-            build_resources_recursively(
-                "Dummy",
-                &serde_yaml::from_str(&format!(
+            ResourceValue::from_value(
+                serde_yaml::from_str(&format!(
                     "!FindInMap [{MAP_NAME}, {FIRST_KEY}, {SECOND_KEY}]"
                 ))
                 .unwrap()
             )
-            .unwrap()
+            .unwrap(),
+            IntrinsicFunction::FindInMap {
+                map_name: ResourceValue::String(MAP_NAME.to_string()),
+                top_level_key: ResourceValue::String(FIRST_KEY.to_string()),
+                second_level_key: ResourceValue::String(SECOND_KEY.to_string())
+            }
+            .into(),
         );
     }
 
@@ -621,39 +376,37 @@ mod test {
         const LOGICAL_NAME: &str = "MapName";
         const ATTRIBUTE_NAME: &str = "FirstKey";
         assert_eq!(
-            ResourceValue::GetAtt(
-                Box::new(ResourceValue::String(LOGICAL_NAME.to_string())),
-                Box::new(ResourceValue::String(ATTRIBUTE_NAME.to_string())),
-            ),
-            build_resources_recursively(
-                "Dummy",
-                &json!({"Fn::GetAtt": [LOGICAL_NAME, ATTRIBUTE_NAME]})
-            )
-            .unwrap()
+            ResourceValue::from_value(json!({"Fn::GetAtt": [LOGICAL_NAME, ATTRIBUTE_NAME]}))
+                .unwrap(),
+            IntrinsicFunction::GetAtt {
+                logical_name: LOGICAL_NAME.into(),
+                attribute_name: ATTRIBUTE_NAME.into(),
+            }
+            .into(),
         );
         // TODO: Confirm the below actually works in CloudFormation (it's not documented!)
         assert_eq!(
-            ResourceValue::GetAtt(
-                Box::new(ResourceValue::String(LOGICAL_NAME.to_string())),
-                Box::new(ResourceValue::String(ATTRIBUTE_NAME.to_string())),
-            ),
-            build_resources_recursively(
-                "Dummy",
-                &serde_yaml::from_str(&format!("!GetAtt [{LOGICAL_NAME}, {ATTRIBUTE_NAME}]"))
+            ResourceValue::from_value(
+                serde_yaml::from_str(&format!("!GetAtt [{LOGICAL_NAME}, {ATTRIBUTE_NAME}]"))
                     .unwrap()
             )
-            .unwrap()
+            .unwrap(),
+            IntrinsicFunction::GetAtt {
+                logical_name: LOGICAL_NAME.into(),
+                attribute_name: ATTRIBUTE_NAME.into(),
+            }
+            .into(),
         );
         assert_eq!(
-            ResourceValue::GetAtt(
-                Box::new(ResourceValue::String(LOGICAL_NAME.to_string())),
-                Box::new(ResourceValue::String(ATTRIBUTE_NAME.to_string())),
-            ),
-            build_resources_recursively(
-                "Dummy",
-                &serde_yaml::from_str(&format!("!GetAtt {LOGICAL_NAME}.{ATTRIBUTE_NAME}")).unwrap()
+            ResourceValue::from_value(
+                serde_yaml::from_str(&format!("!GetAtt {LOGICAL_NAME}.{ATTRIBUTE_NAME}")).unwrap()
             )
-            .unwrap()
+            .unwrap(),
+            IntrinsicFunction::GetAtt {
+                logical_name: LOGICAL_NAME.into(),
+                attribute_name: ATTRIBUTE_NAME.into(),
+            }
+            .into(),
         );
     }
 
@@ -661,16 +414,13 @@ mod test {
     fn intrinsic_get_azs() {
         const REGION: &str = "test-dummy-1337";
         assert_eq!(
-            ResourceValue::GetAZs(Box::new(ResourceValue::String(REGION.to_string()))),
-            build_resources_recursively("Dummy", &json!({ "Fn::GetAZs": REGION })).unwrap(),
+            ResourceValue::from_value(json!({ "Fn::GetAZs": REGION })).unwrap(),
+            IntrinsicFunction::GetAZs(ResourceValue::String(REGION.to_string())).into(),
         );
         assert_eq!(
-            ResourceValue::GetAZs(Box::new(ResourceValue::String(REGION.to_string()))),
-            build_resources_recursively(
-                "Dummy",
-                &serde_yaml::from_str(&format!("!GetAZs {REGION}")).unwrap()
-            )
-            .unwrap(),
+            ResourceValue::from_value(serde_yaml::from_str(&format!("!GetAZs {REGION}")).unwrap())
+                .unwrap(),
+            IntrinsicFunction::GetAZs(ResourceValue::String(REGION.to_string())).into(),
         );
     }
 
@@ -678,17 +428,15 @@ mod test {
     fn intrinsic_import_value() {
         const SHARED_VALUE: &str = "SharedValue.ToImport";
         assert_eq!(
-            ResourceValue::ImportValue(Box::new(ResourceValue::String(SHARED_VALUE.to_string()))),
-            build_resources_recursively("Dummy", &json!({ "Fn::ImportValue": SHARED_VALUE }))
-                .unwrap(),
+            ResourceValue::from_value(json!({ "Fn::ImportValue": SHARED_VALUE })).unwrap(),
+            IntrinsicFunction::ImportValue(ResourceValue::String(SHARED_VALUE.to_string())).into(),
         );
         assert_eq!(
-            ResourceValue::ImportValue(Box::new(ResourceValue::String(SHARED_VALUE.to_string()))),
-            build_resources_recursively(
-                "Dummy",
-                &serde_yaml::from_str(&format!("!ImportValue {SHARED_VALUE}")).unwrap()
+            ResourceValue::from_value(
+                serde_yaml::from_str(&format!("!ImportValue {SHARED_VALUE}")).unwrap()
             )
             .unwrap(),
+            IntrinsicFunction::ImportValue(ResourceValue::String(SHARED_VALUE.to_string())).into(),
         );
     }
 
@@ -698,33 +446,33 @@ mod test {
         const VALUES: [&str; 3] = ["a", "b", "c"];
 
         assert_eq!(
-            ResourceValue::Join(vec![
-                ResourceValue::String(DELIMITER.to_string()),
-                ResourceValue::Array(
+            ResourceValue::from_value(json!({"Fn::Join": [DELIMITER, VALUES]})).unwrap(),
+            IntrinsicFunction::Join {
+                sep: DELIMITER.into(),
+                list: ResourceValue::Array(
                     VALUES
                         .iter()
                         .map(|v| ResourceValue::String(v.to_string()))
                         .collect()
                 )
-            ],),
-            build_resources_recursively("Dummy", &json!({"Fn::Join": [DELIMITER, VALUES]}))
-                .unwrap()
+            }
+            .into(),
         );
         assert_eq!(
-            ResourceValue::Join(vec![
-                ResourceValue::String(DELIMITER.to_string()),
-                ResourceValue::Array(
+            ResourceValue::from_value(
+                serde_yaml::from_str(&format!("!Join [{DELIMITER}, {VALUES:?}]",)).unwrap()
+            )
+            .unwrap(),
+            IntrinsicFunction::Join {
+                sep: DELIMITER.into(),
+                list: ResourceValue::Array(
                     VALUES
                         .iter()
                         .map(|v| ResourceValue::String(v.to_string()))
                         .collect()
                 )
-            ]),
-            build_resources_recursively(
-                "Dummy",
-                &serde_yaml::from_str(&format!("!Join [{DELIMITER}, {VALUES:?}]",)).unwrap()
-            )
-            .unwrap()
+            }
+            .into(),
         );
     }
 
@@ -734,32 +482,33 @@ mod test {
         const VALUES: [&str; 3] = ["a", "b", "c"];
 
         assert_eq!(
-            ResourceValue::Select(
-                Box::new(ResourceValue::Number(INDEX)),
-                Box::new(ResourceValue::Array(
+            ResourceValue::from_value(json!({"Fn::Select": [INDEX, VALUES]})).unwrap(),
+            IntrinsicFunction::Select {
+                index: ResourceValue::Number(INDEX),
+                list: ResourceValue::Array(
                     VALUES
                         .iter()
                         .map(|v| ResourceValue::String(v.to_string()))
                         .collect()
-                ))
-            ),
-            build_resources_recursively("Dummy", &json!({"Fn::Select": [INDEX, VALUES]})).unwrap()
+                )
+            }
+            .into(),
         );
         assert_eq!(
-            ResourceValue::Select(
-                Box::new(ResourceValue::Number(INDEX)),
-                Box::new(ResourceValue::Array(
+            ResourceValue::from_value(
+                serde_yaml::from_str(&format!("!Select [{INDEX}, {VALUES:?}]",)).unwrap()
+            )
+            .unwrap(),
+            IntrinsicFunction::Select {
+                index: ResourceValue::Number(INDEX),
+                list: ResourceValue::Array(
                     VALUES
                         .iter()
                         .map(|v| ResourceValue::String(v.to_string()))
                         .collect()
-                ))
-            ),
-            build_resources_recursively(
-                "Dummy",
-                &serde_yaml::from_str(&format!("!Select [{INDEX}, {VALUES:?}]",)).unwrap()
-            )
-            .unwrap()
+                )
+            }
+            .into(),
         );
     }
 
@@ -769,23 +518,23 @@ mod test {
         const VALUE: &str = "a/b/c";
 
         assert_eq!(
-            ResourceValue::Split(
-                Box::new(ResourceValue::String(DELIMITER.to_string())),
-                Box::new(ResourceValue::String(VALUE.to_string()))
-            ),
-            build_resources_recursively("Dummy", &json!({"Fn::Split": [DELIMITER, VALUE]}))
-                .unwrap()
+            ResourceValue::from_value(json!({"Fn::Split": [DELIMITER, VALUE]})).unwrap(),
+            IntrinsicFunction::Split {
+                sep: DELIMITER.into(),
+                string: ResourceValue::String(VALUE.to_string())
+            }
+            .into(),
         );
         assert_eq!(
-            ResourceValue::Split(
-                Box::new(ResourceValue::String(DELIMITER.to_string())),
-                Box::new(ResourceValue::String(VALUE.to_string()))
-            ),
-            build_resources_recursively(
-                "Dummy",
-                &serde_yaml::from_str(&format!("!Split [{DELIMITER}, {VALUE}]",)).unwrap()
+            ResourceValue::from_value(
+                serde_yaml::from_str(&format!("!Split [{DELIMITER}, {VALUE}]",)).unwrap()
             )
-            .unwrap()
+            .unwrap(),
+            IntrinsicFunction::Split {
+                sep: DELIMITER.into(),
+                string: ResourceValue::String(VALUE.to_string())
+            }
+            .into(),
         );
     }
 
@@ -795,48 +544,51 @@ mod test {
         const CUSTOM: i64 = 1337;
 
         assert_eq!(
-            ResourceValue::Sub(vec![ResourceValue::String(STRING.to_string())]),
-            build_resources_recursively("Dummy", &json!({ "Fn::Sub": STRING })).unwrap()
+            ResourceValue::from_value(json!({ "Fn::Sub": STRING })).unwrap(),
+            IntrinsicFunction::Sub {
+                string: STRING.into(),
+                replaces: None
+            }
+            .into(),
         );
         assert_eq!(
-            ResourceValue::Sub(vec![ResourceValue::String(STRING.to_string())]),
-            build_resources_recursively(
-                "Dummy",
-                &serde_yaml::from_str(&format!("!Sub {STRING}")).unwrap()
-            )
-            .unwrap()
+            ResourceValue::from_value(serde_yaml::from_str(&format!("!Sub {STRING}")).unwrap())
+                .unwrap(),
+            IntrinsicFunction::Sub {
+                string: STRING.into(),
+                replaces: None
+            }
+            .into(),
         );
 
         assert_eq!(
-            ResourceValue::Sub(vec![
-                ResourceValue::String(STRING.to_string(),),
-                ResourceValue::Object(HashMap::from([(
+            ResourceValue::from_value(json!({ "Fn::Sub": [STRING, {"CUSTOM_VARIABLE": CUSTOM}] }))
+                .unwrap(),
+            IntrinsicFunction::Sub {
+                string: STRING.into(),
+                replaces: Some(ResourceValue::Object(HashMap::from([(
                     "CUSTOM_VARIABLE".to_string(),
                     ResourceValue::Number(CUSTOM)
-                )])),
-            ]),
-            build_resources_recursively(
-                "Dummy",
-                &json!({ "Fn::Sub": [STRING, {"CUSTOM_VARIABLE": CUSTOM}] })
-            )
-            .unwrap()
+                )])))
+            }
+            .into(),
         );
         assert_eq!(
-            ResourceValue::Sub(vec![
-                ResourceValue::String(STRING.to_string(),),
-                ResourceValue::Object(HashMap::from([(
-                    "CUSTOM_VARIABLE".to_string(),
-                    ResourceValue::Number(CUSTOM)
-                )])),
-            ]),
-            build_resources_recursively(
-                "Dummy",
-                &serde_yaml::from_str(&format!(
+            ResourceValue::from_value(
+                serde_yaml::from_str(&format!(
                     "!Sub [{STRING:?}, {{ CUSTOM_VARIABLE: {CUSTOM} }}]"
                 ))
                 .unwrap()
             )
-            .unwrap()
+            .unwrap(),
+            IntrinsicFunction::Sub {
+                string: STRING.into(),
+                replaces: Some(ResourceValue::Object(HashMap::from([(
+                    "CUSTOM_VARIABLE".to_string(),
+                    ResourceValue::Number(CUSTOM)
+                )]))),
+            }
+            .into(),
         );
     }
 
@@ -845,16 +597,22 @@ mod test {
         const LOGICAL_NAME: &str = "LogicalName";
 
         assert_eq!(
-            ResourceValue::Ref(LOGICAL_NAME.to_string()),
-            build_resources_recursively("Dummy", &json!({ "Ref": LOGICAL_NAME })).unwrap()
+            ResourceValue::from_value(json!({ "Ref": LOGICAL_NAME })).unwrap(),
+            IntrinsicFunction::Ref(LOGICAL_NAME.to_string()).into(),
         );
         assert_eq!(
-            ResourceValue::Ref(LOGICAL_NAME.to_string()),
-            build_resources_recursively(
-                "Dummy",
-                &serde_yaml::from_str(&format!("!Ref {LOGICAL_NAME}")).unwrap()
+            ResourceValue::from_value(
+                serde_yaml::from_str(&format!("!Ref {LOGICAL_NAME}")).unwrap()
             )
-            .unwrap()
+            .unwrap(),
+            IntrinsicFunction::Ref(LOGICAL_NAME.to_string()).into(),
         );
+    }
+
+    impl ResourceValue {
+        #[inline(always)]
+        fn from_value(value: Value) -> Result<Self, serde_yaml::Error> {
+            serde_yaml::from_value(value)
+        }
     }
 }

--- a/src/parser/resource.rs
+++ b/src/parser/resource.rs
@@ -552,7 +552,24 @@ mod test {
             .into(),
         );
         assert_eq!(
+            ResourceValue::from_value(json!({ "Fn::Sub": [STRING] })).unwrap(),
+            IntrinsicFunction::Sub {
+                string: STRING.into(),
+                replaces: None
+            }
+            .into(),
+        );
+        assert_eq!(
             ResourceValue::from_value(serde_yaml::from_str(&format!("!Sub {STRING}")).unwrap())
+                .unwrap(),
+            IntrinsicFunction::Sub {
+                string: STRING.into(),
+                replaces: None
+            }
+            .into(),
+        );
+        assert_eq!(
+            ResourceValue::from_value(serde_yaml::from_str(&format!("!Sub [{STRING:?}]")).unwrap())
                 .unwrap(),
             IntrinsicFunction::Sub {
                 string: STRING.into(),

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -32,3 +32,27 @@ impl fmt::Display for WrapperF64 {
 }
 
 impl Eq for WrapperF64 {}
+
+impl From<f64> for WrapperF64 {
+    fn from(num: f64) -> Self {
+        WrapperF64::new(num)
+    }
+}
+
+impl From<u64> for WrapperF64 {
+    fn from(num: u64) -> Self {
+        WrapperF64::new(num as f64)
+    }
+}
+
+impl From<i128> for WrapperF64 {
+    fn from(num: i128) -> Self {
+        WrapperF64::new(num as f64)
+    }
+}
+
+impl From<u128> for WrapperF64 {
+    fn from(num: u128) -> Self {
+        WrapperF64::new(num as f64)
+    }
+}


### PR DESCRIPTION
Parse directly into the `*ParseTree` structures instead of going through `serde_yaml::Value` as an initial step. This replaces a bunch of `Derive` implementations of `serde::Deserialize` with hand-coded ones, and completely removes the `build_resource_recursively` function (in favor of directly parsing).

This is not the complete implementation of the refactor (it'd be too big), and instead of an initial pass that focuses specifically on the `ResourceValue` `enum`. It also refactored intrinsics into an `IntrinsicFunction` `enum` to make the semantics a little easier to track here, and also to consolidate the parsing logic in a separate location.