### PR TITLE
feat: track reference origin nullability

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,22 +1,23 @@
 coverage:
   precision: 1
   round: nearest
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2% # Allow coverage to drop slightly
+        removed_code_behavior: adjust_base
+    patch:
+      default:
+        target: auto
+        threshold: 5% # Allow coverage to drop slightly
+        removed_code_behavior: adjust_base
 
 comment:
   layout: header, components, diff, files, footer
   behavior: new
 
 component_management:
-  default_rules:
-    statuses:
-      - type: project
-        target: auto
-        threshold: 2% # Allow coverage to drop slightly
-        removed_code_behavior: adjust_base
-        branches: ['!main']
-      - type: patch
-        only_pulls: true
-        removed_code_behavior: adjust_base
   individual_components:
     - component_id: parser
       name: Parser

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  precision: 1
+  round: nearest
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2% # Allow coverage to drop slightly
+        removed_code_behavior: adjust_base
+    patch:
+      default:
+        target: auto
+        only_pulls: true
+        removed_code_behavior: adjust_base
+
+comment:
+  layout: reach, diff, files
+  behavior: new

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,18 +1,40 @@
 coverage:
   precision: 1
   round: nearest
-  status:
-    project:
-      default:
+
+comment:
+  layout: header, components, reach, diff, files, footer
+  behavior: new
+
+component_management:
+  default_rules:
+    statuses:
+      - type: project
         target: auto
         threshold: 2% # Allow coverage to drop slightly
         removed_code_behavior: adjust_base
-    patch:
-      default:
-        target: auto
+        branches: ['!main']
+      - type: patch
         only_pulls: true
         removed_code_behavior: adjust_base
-
-comment:
-  layout: reach, diff, files
-  behavior: new
+  individual_components:
+    - component_id: parser
+      name: Parser
+      paths:
+        - src/parser/**
+    - component_id: ir
+      name: Intermediate Representation
+      paths:
+        - src/ir/**
+    - component_id: synthesizer
+      name: Synthesizers
+      paths:
+        - src/synthesizer/**
+    - component_id: other
+      name: Other
+      paths:
+        - src/errors/**
+        - src/integrations/**
+        - src/primitives/**
+        - src/specification/**
+        - src/*.rs

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,7 +3,7 @@ coverage:
   round: nearest
 
 comment:
-  layout: header, components, reach, diff, files, footer
+  layout: header, components, diff, files, footer
   behavior: new
 
 component_management:

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -49,8 +49,5 @@ jobs:
           directory: target/coverage
           fail_ci_if_error: true
           gcov: true
-          gcov_ignore:
-            - src/main.rs
-            - src/**/tests.rs
-            - tests/**
+          gcov_ignore: "src/main.rs,src/**/tests.rs,tests/**"
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -41,12 +41,12 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-          components: llvm-tools-preview
       - name: Tests with Coverage
         run: bash tasks/coverage.sh
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: target/coverage/lcov.info
+          files: target/coverage/deps/*.gcda
           fail_ci_if_error: true
+          gcov: true

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -46,7 +46,11 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: target/coverage/deps/*.gcda
+          directory: target/coverage
           fail_ci_if_error: true
           gcov: true
+          gcov_ignore:
+            - src/main.rs
+            - src/**/tests.rs
+            - tests/**
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,4 +38,6 @@ opt-level = 3
 
 [profile.coverage]
 inherits = "test"
+codegen-units = 1
 incremental = false
+opt-level = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,4 @@ inherits = "test"
 codegen-units = 1
 incremental = false
 opt-level = 0
+panic = "abort"

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -16,12 +16,14 @@ impl TransmuteError {
 }
 
 impl From<serde_yaml::Error> for TransmuteError {
+    #[inline]
     fn from(val: serde_yaml::Error) -> Self {
         TransmuteError::new(val)
     }
 }
 
 impl fmt::Display for TransmuteError {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "TransmuteError: {}", self.details)
     }

--- a/src/ir/conditions.rs
+++ b/src/ir/conditions.rs
@@ -52,6 +52,7 @@ pub enum ConditionIr {
 }
 
 impl ConditionIr {
+    #[inline]
     pub fn is_simple(&self) -> bool {
         matches!(self, Self::Str(_) | Self::Ref(_))
     }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -69,12 +69,14 @@ impl ReferenceOrigins {
                 .map(|(name, _)| (name.clone(), Origin::Parameter)),
         );
 
-        origins.extend(
-            parse_tree
-                .resources
-                .iter()
-                .map(|(name, _)| (name.clone(), Origin::LogicalId)),
-        );
+        origins.extend(parse_tree.resources.iter().map(|(name, res)| {
+            (
+                name.clone(),
+                Origin::LogicalId {
+                    conditional: res.condition.is_some(),
+                },
+            )
+        }));
 
         Self { origins }
     }
@@ -85,5 +87,14 @@ impl ReferenceOrigins {
         } else {
             self.origins.get(ref_name).cloned()
         }
+    }
+
+    fn is_conditional(&self, logical_id: &str) -> bool {
+        self.for_ref(logical_id)
+            .map(|orig| match orig {
+                Origin::LogicalId { conditional } => conditional,
+                _ => false,
+            })
+            .unwrap_or(false)
     }
 }

--- a/src/ir/resources.rs
+++ b/src/ir/resources.rs
@@ -197,11 +197,11 @@ impl<'t> ResourceTranslator<'t> {
                     }
                     IntrinsicFunction::GetAtt {
                         logical_name,
-                        attribute_name: attribute,
+                        attribute_name,
                     } => Ok(ResourceIr::Ref(Reference::new(
                         &logical_name,
                         Origin::GetAttribute {
-                            attribute,
+                            attribute: attribute_name,
                             conditional: self.origins.is_conditional(&logical_name),
                         },
                     ))),

--- a/src/ir/resources.rs
+++ b/src/ir/resources.rs
@@ -197,10 +197,13 @@ impl<'t> ResourceTranslator<'t> {
                     }
                     IntrinsicFunction::GetAtt {
                         logical_name,
-                        attribute_name,
+                        attribute_name: attribute,
                     } => Ok(ResourceIr::Ref(Reference::new(
                         &logical_name,
-                        Origin::GetAttribute(attribute_name),
+                        Origin::GetAttribute {
+                            attribute,
+                            conditional: self.origins.is_conditional(&logical_name),
+                        },
                     ))),
                     IntrinsicFunction::If {
                         condition_name,
@@ -293,9 +296,15 @@ impl<'t> ResourceTranslator<'t> {
         if let Some(origin) = self.origins.for_ref(x) {
             Reference::new(x, origin)
         } else if let Some((name, attribute)) = x.split_once('.') {
-            Reference::new(name, Origin::GetAttribute(attribute.into()))
+            Reference::new(
+                name,
+                Origin::GetAttribute {
+                    attribute: attribute.into(),
+                    conditional: self.origins.is_conditional(name),
+                },
+            )
         } else {
-            Reference::new(x, Origin::LogicalId)
+            Reference::new(x, Origin::LogicalId { conditional: false })
         }
     }
 
@@ -503,8 +512,8 @@ fn find_references(resource: &ResourceIr) -> Option<Vec<String>> {
         ResourceIr::Split(_, ir) => find_references(ir),
         ResourceIr::Ref(x) => match x.origin {
             Origin::Parameter | Origin::Condition | Origin::PseudoParameter(_) => None,
-            Origin::LogicalId => Some(vec![x.name.to_string()]),
-            Origin::GetAttribute(_) => Some(vec![x.name.to_string()]),
+            Origin::LogicalId { .. } => Some(vec![x.name.to_string()]),
+            Origin::GetAttribute { .. } => Some(vec![x.name.to_string()]),
         },
         ResourceIr::Sub(arr) => {
             let mut v = Vec::new();
@@ -580,10 +589,10 @@ fn find_dependencies(
         ResourceIr::Split(_, ir) => find_dependencies(resource_name, ir, topo),
         ResourceIr::Ref(x) => match x.origin {
             Origin::Parameter | Origin::Condition | Origin::PseudoParameter(_) => {}
-            Origin::LogicalId => {
+            Origin::LogicalId { .. } => {
                 topo.add_dependency(x.name.to_string(), resource_name.to_string());
             }
-            Origin::GetAttribute(_) => {
+            Origin::GetAttribute { .. } => {
                 topo.add_dependency(x.name.to_string(), resource_name.to_string());
             }
         },
@@ -647,7 +656,10 @@ mod tests {
             referrers: HashSet::default(),
             properties: create_property(
                 "something",
-                ResourceIr::Ref(Reference::new("A", Origin::LogicalId)),
+                ResourceIr::Ref(Reference::new(
+                    "A",
+                    Origin::LogicalId { conditional: false },
+                )),
             ),
         };
 
@@ -670,7 +682,10 @@ mod tests {
             referrers: HashSet::default(),
             properties: create_property(
                 "something",
-                ResourceIr::Ref(Reference::new("bar", Origin::LogicalId)),
+                ResourceIr::Ref(Reference::new(
+                    "bar",
+                    Origin::LogicalId { conditional: false },
+                )),
             ),
         };
 

--- a/tests/end-to-end/simple/app.ts
+++ b/tests/end-to-end/simple/app.ts
@@ -116,7 +116,7 @@ export class NoctStack extends cdk.Stack {
 
     // Outputs
     this.bucketArn = isUsEast1
-      ? bucket.attrArn
+      ? bucket?.attrArn
       : undefined;
     if (isUsEast1) {
       new cdk.CfnOutput(this, 'BucketArn', {


### PR DESCRIPTION
Allows emitting optional-chained references when the origin is conditional, so as to avoid the TypeScript compiler complaining about possibly null dereference.