### PR TITLE
chore: Fix PR Action

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -38,7 +38,7 @@ jobs:
         run: "git diff src/specification/spec.json"
 
       - name: "Open pull request updating schema"
-        uses: "gr2m/create-or-update-pull-request-action@v1.9.2"
+        uses: "gr2m/create-or-update-pull-request-action@v1"
         with:
           author: "Sean Myers <seanmyers608@gmail.com>"
           branch: "feature/schema"


### PR DESCRIPTION
Pull Requests for schema changes are no longer working. They started to break because in v1.5+, dist files were no longer included in the action -- so things are just busted. 

The recommendation both on the marketplace and the issue is to just use the recommended version (either v1.x or v1). We don't need advanced functionality, so tagging us to v1.