### PR TITLE
feat: allow split/select to be used in conditions

### DIFF
--- a/src/ir/conditions/mod.rs
+++ b/src/ir/conditions/mod.rs
@@ -46,6 +46,8 @@ pub enum ConditionIr {
     // Cloudformation meta-functions
     Map(String, Box<ConditionIr>, Box<ConditionIr>),
     Split(String, Box<ConditionIr>),
+    Select(String, Box<ConditionIr>),
+
     // End of recursion, the base primitives to work with
     Str(String),
     Ref(Reference),
@@ -97,6 +99,10 @@ impl ConditionValue {
             Self::Split(delimiter, x) => {
                 let x = x.into_ir();
                 ConditionIr::Split(delimiter, Box::new(x))
+            }
+            Self::Select(index, x) => {
+                let x = x.into_ir();
+                ConditionIr::Select(index, Box::new(x))
             }
             Self::String(x) => ConditionIr::Str(x),
             Self::Ref(name) => {
@@ -185,6 +191,9 @@ impl ConditionValue {
                 key2.find_dependencies(logical_id, topo_sort);
             }
             Self::Split(_, key1) => {
+                key1.find_dependencies(logical_id, topo_sort);
+            }
+            Self::Select(_, key1) => {
                 key1.find_dependencies(logical_id, topo_sort);
             }
             Self::Function(func) => func.find_dependencies(logical_id, topo_sort),

--- a/src/ir/conditions/mod.rs
+++ b/src/ir/conditions/mod.rs
@@ -45,7 +45,7 @@ pub enum ConditionIr {
 
     // Cloudformation meta-functions
     Map(String, Box<ConditionIr>, Box<ConditionIr>),
-
+    Split(String, Box<ConditionIr>),
     // End of recursion, the base primitives to work with
     Str(String),
     Ref(Reference),
@@ -93,6 +93,10 @@ impl ConditionValue {
                 let y = y.into_ir();
 
                 ConditionIr::Map(name, Box::new(x), Box::new(y))
+            }
+            Self::Split(delimiter, x) => {
+                let x = x.into_ir();
+                ConditionIr::Split(delimiter, Box::new(x))
             }
             Self::String(x) => ConditionIr::Str(x),
             Self::Ref(name) => {
@@ -179,6 +183,9 @@ impl ConditionValue {
             Self::FindInMap(_, key1, key2) => {
                 key1.find_dependencies(logical_id, topo_sort);
                 key2.find_dependencies(logical_id, topo_sort);
+            }
+            Self::Split(_, key1) => {
+                key1.find_dependencies(logical_id, topo_sort);
             }
             Self::Function(func) => func.find_dependencies(logical_id, topo_sort),
             Self::Ref(_) | Self::String(_) => {}

--- a/src/parser/condition/mod.rs
+++ b/src/parser/condition/mod.rs
@@ -198,6 +198,13 @@ impl<'de> serde::Deserialize<'de> for ConditionValue {
                             top_level_key,
                             second_level_key,
                         ))
+                    },
+                    "!Split" | "Fn::Split" => {
+                        let (delimiter, split_str) = data.next_value()?;
+                        Ok(Self::Value::Split(
+                            delimiter,
+                            split_str,
+                        ))
                     }
                     "!Ref" | "Ref" => Ok(Self::Value::Ref(data.next_value()?)),
                     other => Ok(ConditionFunction::from_map_access(other, &mut data)?.into()),

--- a/src/parser/condition/mod.rs
+++ b/src/parser/condition/mod.rs
@@ -116,7 +116,7 @@ pub enum ConditionValue {
 
     // Cloudformation meta-functions
     FindInMap(String, Box<ConditionValue>, Box<ConditionValue>),
-
+    Split(String, Box<ConditionValue>),
     // End of recursion, the base primitives to work with
     String(String),
     Ref(String),
@@ -159,6 +159,10 @@ impl<'de> serde::Deserialize<'de> for ConditionValue {
                             top_level_key,
                             second_level_key,
                         ))
+                    }
+                    "Split" => {
+                        let (delimiter, source_string) = data.newtype_variant()?;
+                        Ok(Self::Value::Split(delimiter, source_string))
                     }
                     "Ref" => Ok(Self::Value::Ref(data.newtype_variant()?)),
                     other => Ok(ConditionFunction::from_variant_access(other, data)?.into()),

--- a/src/parser/condition/mod.rs
+++ b/src/parser/condition/mod.rs
@@ -198,13 +198,10 @@ impl<'de> serde::Deserialize<'de> for ConditionValue {
                             top_level_key,
                             second_level_key,
                         ))
-                    },
+                    }
                     "!Split" | "Fn::Split" => {
                         let (delimiter, split_str) = data.next_value()?;
-                        Ok(Self::Value::Split(
-                            delimiter,
-                            split_str,
-                        ))
+                        Ok(Self::Value::Split(delimiter, split_str))
                     }
                     "!Ref" | "Ref" => Ok(Self::Value::Ref(data.next_value()?)),
                     other => Ok(ConditionFunction::from_map_access(other, &mut data)?.into()),

--- a/src/parser/condition/mod.rs
+++ b/src/parser/condition/mod.rs
@@ -117,6 +117,7 @@ pub enum ConditionValue {
     // Cloudformation meta-functions
     FindInMap(String, Box<ConditionValue>, Box<ConditionValue>),
     Split(String, Box<ConditionValue>),
+    Select(String, Box<ConditionValue>),
     // End of recursion, the base primitives to work with
     String(String),
     Ref(String),
@@ -164,6 +165,10 @@ impl<'de> serde::Deserialize<'de> for ConditionValue {
                         let (delimiter, source_string) = data.newtype_variant()?;
                         Ok(Self::Value::Split(delimiter, source_string))
                     }
+                    "Select" => {
+                        let (index, source_array) = data.newtype_variant()?;
+                        Ok(Self::Value::Select(index, source_array))
+                    }
                     "Ref" => Ok(Self::Value::Ref(data.newtype_variant()?)),
                     other => Ok(ConditionFunction::from_variant_access(other, data)?.into()),
                 }
@@ -202,6 +207,10 @@ impl<'de> serde::Deserialize<'de> for ConditionValue {
                     "!Split" | "Fn::Split" => {
                         let (delimiter, split_str) = data.next_value()?;
                         Ok(Self::Value::Split(delimiter, split_str))
+                    }
+                    "!Select" | "Fn::Select" => {
+                        let (index, array) = data.next_value()?;
+                        Ok(Self::Value::Select(index, array))
                     }
                     "!Ref" | "Ref" => Ok(Self::Value::Ref(data.next_value()?)),
                     other => Ok(ConditionFunction::from_map_access(other, &mut data)?.into()),

--- a/src/parser/condition/tests.rs
+++ b/src/parser/condition/tests.rs
@@ -182,6 +182,22 @@ fn condition_find_in_map() {
 }
 
 #[test]
+fn condition_split() {
+    let expected = ConditionValue::Split(
+        ",".into(),
+        Box::new(ConditionValue::String("hello,world".into())),
+    );
+    assert_eq!(
+        expected,
+        serde_yaml::from_str("!Split [\",\", \"hello,world\"]").unwrap()
+    );
+    assert_eq!(
+        expected,
+        serde_yaml::from_str("Fn::Split: [\",\", \"hello,world\"]").unwrap()
+    );
+}
+
+#[test]
 fn condition_str_bool() {
     let expected = ConditionValue::String("true".into());
     assert_eq!(expected, serde_yaml::from_str("true").unwrap());

--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -494,6 +494,11 @@ impl GolangEmitter for ConditionIr {
                 slk.emit_golang(context, output, None);
                 output.text("]");
             }
+            ConditionIr::Split(sep, str) => {
+                output.text(format!("cdk.Fn_Split(jsii.String({sep:?}), "));
+                str.emit_golang(context, output, None);
+                output.text(")");
+            }
         }
         if let Some(trailer) = trailer {
             output.text(trailer.to_owned())

--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -361,6 +361,7 @@ impl Inspectable for ConditionIr {
             }
             ConditionIr::Map(map_name, _, _) => map_name == name,
             ConditionIr::Split(_, cond) => cond.uses_map_table(name),
+            ConditionIr::Select(_, cond) => cond.uses_map_table(name),
             ConditionIr::Str(_) | ConditionIr::Ref(_) => false,
         }
     }
@@ -497,6 +498,11 @@ impl GolangEmitter for ConditionIr {
             }
             ConditionIr::Split(sep, str) => {
                 output.text(format!("cdk.Fn_Split(jsii.String({sep:?}), "));
+                str.emit_golang(context, output, None);
+                output.text(")");
+            }
+            ConditionIr::Select(index, str) => {
+                output.text(format!("cdk.Fn_Select(jsii.Number({index:?}), "));
                 str.emit_golang(context, output, None);
                 output.text(")");
             }

--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -360,6 +360,7 @@ impl Inspectable for ConditionIr {
                 list.iter().any(|cond| cond.uses_map_table(name))
             }
             ConditionIr::Map(map_name, _, _) => map_name == name,
+            ConditionIr::Split(_, cond) => cond.uses_map_table(name),
             ConditionIr::Str(_) | ConditionIr::Ref(_) => false,
         }
     }

--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -635,6 +635,14 @@ fn synthesize_condition_recursive(val: &ConditionIr) -> String {
                 synthesize_condition_recursive(l2.as_ref())
             )
         }
+        ConditionIr::Split(sep, l1) => {
+            let str = synthesize_condition_recursive(l1.as_ref());
+            format!(
+                "'${str}'.split('{sep}')",
+                str = str.escape_debug(),
+                sep = sep.escape_debug()
+            )
+        }
     }
 }
 

--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -638,10 +638,14 @@ fn synthesize_condition_recursive(val: &ConditionIr) -> String {
         ConditionIr::Split(sep, l1) => {
             let str = synthesize_condition_recursive(l1.as_ref());
             format!(
-                "'${str}'.split('{sep}')",
+                "{str}.split('{sep}')",
                 str = str.escape_debug(),
                 sep = sep.escape_debug()
             )
+        }
+        ConditionIr::Select(index, l1) => {
+            let str = synthesize_condition_recursive(l1.as_ref());
+            format!("cdk.Fn.select({index}, {str})")
         }
     }
 }

--- a/tests/end-to-end/simple/app.go
+++ b/tests/end-to-end/simple/app.go
@@ -1,4 +1,4 @@
-package main
+package simple
 
 import (
 	"fmt"

--- a/tests/end-to-end/simple/app.go
+++ b/tests/end-to-end/simple/app.go
@@ -1,4 +1,4 @@
-package simple
+package main
 
 import (
 	"fmt"
@@ -89,6 +89,8 @@ func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *
 	}
 
 	stack := cdk.NewStack(scope, &id, &props.StackProps)
+
+	isUs := cdk.Fn_Select(jsii.Number("0"), cdk.Fn_Split(jsii.String("-"), stack.Region())) == jsii.String("us")
 
 	isUsEast1 := stack.Region() == jsii.String("us-east-1")
 

--- a/tests/end-to-end/simple/app.ts
+++ b/tests/end-to-end/simple/app.ts
@@ -77,6 +77,7 @@ export class NoctStack extends cdk.Stack {
     };
 
     // Conditions
+    const isUs = cdk.Fn.select(0, this.region.split('-')) === 'us';
     const isUsEast1 = this.region === 'us-east-1';
 
     // Resources

--- a/tests/end-to-end/simple/template.yml
+++ b/tests/end-to-end/simple/template.yml
@@ -37,7 +37,14 @@ Conditions:
     Fn::Equals:
       - !Ref AWS::Region
       - us-east-1
-
+  IsUs:
+    Fn::Equals:
+      - Fn::Select:
+        - 0
+        - Fn::Split:
+          - "-"
+          - "!Ref": AWS::Region
+      - us
 Parameters:
   BucketNamePrefix:
     Type: String


### PR DESCRIPTION
Turns out you can use split (and probably join) in conditions. This adds the functionality for split to be used, which unblocks a few templates found that require that.