### PR TITLE
feat: Allow Conditions to be used in isolation

### DIFF
--- a/src/ir/conditions/mod.rs
+++ b/src/ir/conditions/mod.rs
@@ -42,6 +42,7 @@ pub enum ConditionIr {
     Equals(Box<ConditionIr>, Box<ConditionIr>),
     Not(Box<ConditionIr>),
     Or(Vec<ConditionIr>),
+    Condition(String),
 
     // Cloudformation meta-functions
     Map(String, Box<ConditionIr>, Box<ConditionIr>),
@@ -78,6 +79,9 @@ impl ConditionFunction {
             Self::Or(x) => {
                 let or_list = x.into_iter().map(ConditionValue::into_ir).collect();
                 ConditionIr::Or(or_list)
+            }
+            Self::Condition(x) => {
+                ConditionIr::Condition(x)
             }
             Self::If { .. } => unimplemented!(),
         }
@@ -150,6 +154,9 @@ impl ConditionFunction {
             Self::Equals(a, b) => {
                 a.find_dependencies(logical_id, topo_sort);
                 b.find_dependencies(logical_id, topo_sort);
+            }
+            Self::Condition(x) => {
+                topo_sort.add_dependency(x.as_str(), logical_id);
             }
             Self::Not(cond) => cond.find_dependencies(logical_id, topo_sort),
             Self::If {

--- a/src/ir/conditions/mod.rs
+++ b/src/ir/conditions/mod.rs
@@ -80,9 +80,7 @@ impl ConditionFunction {
                 let or_list = x.into_iter().map(ConditionValue::into_ir).collect();
                 ConditionIr::Or(or_list)
             }
-            Self::Condition(x) => {
-                ConditionIr::Condition(x)
-            }
+            Self::Condition(x) => ConditionIr::Condition(x),
             Self::If { .. } => unimplemented!(),
         }
     }

--- a/src/parser/condition/mod.rs
+++ b/src/parser/condition/mod.rs
@@ -11,7 +11,7 @@ pub enum ConditionFunction {
         if_false: ConditionValue,
     },
     Not(ConditionValue),
-    Condition(String)
+    Condition(String),
 }
 
 impl ConditionFunction {
@@ -67,7 +67,14 @@ impl ConditionFunction {
             "!Not" | "Fn::Not" => Ok(Self::Not(data.next_value::<Singleton>()?.unwrap())),
             unknown => Err(A::Error::unknown_variant(
                 unknown,
-                &["Fn::And", "Fn::Or", "Fn::Equals", "Fn::If", "Fn::Not", "Condition"],
+                &[
+                    "Fn::And",
+                    "Fn::Or",
+                    "Fn::Equals",
+                    "Fn::If",
+                    "Fn::Not",
+                    "Condition",
+                ],
             )),
         }
     }

--- a/src/parser/condition/mod.rs
+++ b/src/parser/condition/mod.rs
@@ -11,6 +11,7 @@ pub enum ConditionFunction {
         if_false: ConditionValue,
     },
     Not(ConditionValue),
+    Condition(String)
 }
 
 impl ConditionFunction {
@@ -34,9 +35,11 @@ impl ConditionFunction {
                 })
             }
             "Not" => Ok(Self::Not(data.newtype_variant::<Singleton>()?.unwrap())),
+            "Condition" => Ok(Self::Condition(data.newtype_variant()?)),
+
             unknown => Err(A::Error::unknown_variant(
                 unknown,
-                &["And", "Or", "Equals", "If", "Not"],
+                &["And", "Or", "Equals", "If", "Not", "Condition"],
             )),
         }
     }
@@ -48,6 +51,7 @@ impl ConditionFunction {
         match variant {
             "!And" | "Fn::And" => Ok(Self::And(data.next_value()?)),
             "!Or" | "Fn::Or" => Ok(Self::Or(data.next_value()?)),
+            "Condition" => Ok(Self::Condition(data.next_value()?)),
             "!Equals" | "Fn::Equals" => {
                 let (left, right) = data.next_value()?;
                 Ok(Self::Equals(left, right))
@@ -63,7 +67,7 @@ impl ConditionFunction {
             "!Not" | "Fn::Not" => Ok(Self::Not(data.next_value::<Singleton>()?.unwrap())),
             unknown => Err(A::Error::unknown_variant(
                 unknown,
-                &["Fn::And", "Fn::Or", "Fn::Equals", "Fn::If", "Fn::Not"],
+                &["Fn::And", "Fn::Or", "Fn::Equals", "Fn::If", "Fn::Not", "Condition"],
             )),
         }
     }

--- a/src/parser/condition/tests.rs
+++ b/src/parser/condition/tests.rs
@@ -231,6 +231,19 @@ fn condition_ref() {
     assert_eq!(expected, serde_yaml::from_str("Ref: LogicalID").unwrap());
 }
 
+// Functions are boolean operators and Conditions top level must end in a boolean, so this tests
+// confirm failures for using intrinsics incorrectly.
+#[test]
+fn condition_function_failure() {
+    let x: serde_yaml::Result<ConditionFunction> = serde_yaml::from_str("!Ref LogicalID");
+    let y: serde_yaml::Result<ConditionFunction> = serde_yaml::from_str("Fn::Cidr: [\"192.168.0.0/24\", 6, 5]");
+    let x = x.err().unwrap().to_string();
+    let y = y.err().unwrap().to_string();
+
+    assert!(x.contains("unknown variant"));
+    assert!(y.contains("unknown variant"));
+}
+
 #[test]
 fn condition_condition() {
     let expected = ConditionValue::Condition("LogicalID".into());

--- a/src/parser/condition/tests.rs
+++ b/src/parser/condition/tests.rs
@@ -236,7 +236,8 @@ fn condition_ref() {
 #[test]
 fn condition_function_failure() {
     let x: serde_yaml::Result<ConditionFunction> = serde_yaml::from_str("!Ref LogicalID");
-    let y: serde_yaml::Result<ConditionFunction> = serde_yaml::from_str("Fn::Cidr: [\"192.168.0.0/24\", 6, 5]");
+    let y: serde_yaml::Result<ConditionFunction> =
+        serde_yaml::from_str("Fn::Cidr: [\"192.168.0.0/24\", 6, 5]");
     let x = x.err().unwrap().to_string();
     let y = y.err().unwrap().to_string();
 

--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -457,7 +457,7 @@ impl GolangEmitter for ConditionIr {
         match self {
             Self::Ref(reference) => reference.emit_golang(context, output, None),
             Self::Str(str) => output.text(format!("jsii.String({str:?})")),
-            Self::Condition(x) => output.text(format!("{x}",x=golang_identifier(x, IdentifierKind::Unexported))),
+            Self::Condition(x) => output.text(golang_identifier(x, IdentifierKind::Unexported)),
 
             Self::And(list) => {
                 for (idx, cond) in list.iter().enumerate() {

--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -360,7 +360,7 @@ impl Inspectable for ConditionIr {
                 list.iter().any(|cond| cond.uses_map_table(name))
             }
             ConditionIr::Map(map_name, _, _) => map_name == name,
-            ConditionIr::Str(_) | ConditionIr::Ref(_) => false,
+            ConditionIr::Condition(_) | ConditionIr::Str(_) | ConditionIr::Ref(_) => false,
         }
     }
 }
@@ -457,6 +457,7 @@ impl GolangEmitter for ConditionIr {
         match self {
             Self::Ref(reference) => reference.emit_golang(context, output, None),
             Self::Str(str) => output.text(format!("jsii.String({str:?})")),
+            Self::Condition(x) => output.text(format!("{x}",x=golang_identifier(x, IdentifierKind::Unexported))),
 
             Self::And(list) => {
                 for (idx, cond) in list.iter().enumerate() {

--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -626,9 +626,7 @@ fn synthesize_condition_recursive(val: &ConditionIr) -> String {
         ConditionIr::Str(x) => {
             format!("'{x}'")
         }
-        ConditionIr::Condition(x) => {
-            format!("{x}", x=pretty_name(x))
-        }
+        ConditionIr::Condition(x) => pretty_name(x),
         ConditionIr::Ref(x) => x.to_typescript().into(),
         ConditionIr::Map(named_resource, l1, l2) => {
             format!(

--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -626,6 +626,9 @@ fn synthesize_condition_recursive(val: &ConditionIr) -> String {
         ConditionIr::Str(x) => {
             format!("'{x}'")
         }
+        ConditionIr::Condition(x) => {
+            format!("{x}", x=pretty_name(x))
+        }
         ConditionIr::Ref(x) => x.to_typescript().into(),
         ConditionIr::Map(named_resource, l1, l2) => {
             format!(

--- a/tests/end-to-end/simple/app.go
+++ b/tests/end-to-end/simple/app.go
@@ -92,6 +92,8 @@ func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *
 
 	isUsEast1 := stack.Region() == jsii.String("us-east-1")
 
+	isLargeRegion := isUsEast1
+
 	queue := sqs.NewCfnQueue(
 		stack,
 		jsii.String("Queue"),

--- a/tests/end-to-end/simple/app.ts
+++ b/tests/end-to-end/simple/app.ts
@@ -78,6 +78,7 @@ export class NoctStack extends cdk.Stack {
 
     // Conditions
     const isUsEast1 = this.region === 'us-east-1';
+    const isLargeRegion = isUsEast1;
 
     // Resources
     const queue = new sqs.CfnQueue(this, 'Queue', {

--- a/tests/end-to-end/simple/template.yml
+++ b/tests/end-to-end/simple/template.yml
@@ -33,6 +33,8 @@ Mappings:
       String: Baz
 
 Conditions:
+  IsLargeRegion:
+    Condition: IsUsEast1
   IsUsEast1:
     Fn::Equals:
       - !Ref AWS::Region


### PR DESCRIPTION
Apparently conditions can just be "another condition". Weird use case, but I've found some templates that have this. Added Condition as the highest level to allow those templates to work.