### PR TITLE
fix(go): use generics trick to implement `Fn::If`

### DIFF
--- a/src/ir/conditions/mod.rs
+++ b/src/ir/conditions/mod.rs
@@ -47,7 +47,7 @@ pub enum ConditionIr {
     // Cloudformation meta-functions
     Map(String, Box<ConditionIr>, Box<ConditionIr>),
     Split(String, Box<ConditionIr>),
-    Select(String, Box<ConditionIr>),
+    Select(usize, Box<ConditionIr>),
 
     // End of recursion, the base primitives to work with
     Str(String),

--- a/src/parser/condition/mod.rs
+++ b/src/parser/condition/mod.rs
@@ -128,7 +128,7 @@ pub enum ConditionValue {
     // Cloudformation meta-functions
     FindInMap(String, Box<ConditionValue>, Box<ConditionValue>),
     Split(String, Box<ConditionValue>),
-    Select(String, Box<ConditionValue>),
+    Select(usize, Box<ConditionValue>),
     // End of recursion, the base primitives to work with
     String(String),
     Ref(String),

--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -18,6 +18,7 @@ use voca_rs::case::{camel_case, pascal_case, snake_case};
 use super::Synthesizer;
 
 const INDENT: Cow<'static, str> = Cow::Borrowed("\t");
+const TERNARY: &str = "ifCondition";
 
 pub struct Golang {
     package_name: String,
@@ -50,12 +51,7 @@ impl Synthesizer for Golang {
             trailing: Some(")".into()),
             trailing_newline: true,
         });
-        let context = &mut {
-            let fmt = imports.section(false);
-            let time = imports.section(false);
-            let blank = imports.section(false);
-            GoContext::new(fmt, time, blank)
-        };
+        let stdlib_imports = imports.section(false);
 
         for import in &ir.imports {
             imports.line(import.to_golang());
@@ -108,6 +104,14 @@ impl Synthesizer for Golang {
             trailing: Some("}".into()),
             trailing_newline: true,
         });
+
+        let context = &mut {
+            let fmt = stdlib_imports.section(false);
+            let time = stdlib_imports.section(false);
+            let blank = stdlib_imports.section(false);
+            let ternary = code.section(false);
+            GoContext::new(fmt, time, blank, ternary)
+        };
 
         for mapping in &ir.mappings {
             let leaf_type = match mapping.output_type() {
@@ -288,19 +292,28 @@ struct GoContext {
     fmt: Rc<CodeBuffer>,
     time: Rc<CodeBuffer>,
     blank: Rc<CodeBuffer>,
+    ternary: Rc<CodeBuffer>,
     has_fmt: bool,
     has_time: bool,
     has_blank: bool,
+    has_ternary: bool,
 }
 impl GoContext {
-    const fn new(fmt: Rc<CodeBuffer>, time: Rc<CodeBuffer>, blank: Rc<CodeBuffer>) -> Self {
+    const fn new(
+        fmt: Rc<CodeBuffer>,
+        time: Rc<CodeBuffer>,
+        blank: Rc<CodeBuffer>,
+        ternary: Rc<CodeBuffer>,
+    ) -> Self {
         Self {
             fmt,
             time,
             blank,
+            ternary,
             has_fmt: false,
             has_time: false,
             has_blank: false,
+            has_ternary: false,
         }
     }
 
@@ -330,6 +343,39 @@ impl GoContext {
         }
         self.blank.newline();
         self.has_blank = true;
+    }
+
+    fn insert_ternary(&mut self) {
+        if self.has_ternary {
+            return;
+        }
+
+        self.ternary.newline();
+        let comment = self.ternary.indent("/// ".into());
+        comment.line("ifCondition is a helper function that replicates the ternary");
+        comment.line("operator that can be found in other languages. It is conceptually");
+        comment.line("equivalent to writing `cond ? whenTrue : whenFalse`, meaning it");
+        comment.line("returns `whenTrue` if `cond` is `true`, and `whenFalse` otherwise.");
+        let block = self.ternary.indent_with_options(IndentOptions {
+            indent: INDENT,
+            leading: Some(
+                format!("func {TERNARY}[T any](cond bool, whenTrue T, whenFalse T) T {{").into(),
+            ),
+            trailing: Some("}".into()),
+            trailing_newline: true,
+        });
+
+        block
+            .indent_with_options(IndentOptions {
+                indent: INDENT,
+                leading: Some("if cond {".into()),
+                trailing: Some("}".into()),
+                trailing_newline: true,
+            })
+            .line("return whenTrue");
+        block.line("return whenFalse");
+
+        self.has_ternary = true;
     }
 }
 
@@ -363,7 +409,6 @@ impl Inspectable for ConditionIr {
             ConditionIr::Condition(_) | ConditionIr::Str(_) | ConditionIr::Ref(_) => false,
             ConditionIr::Split(_, cond) => cond.uses_map_table(name),
             ConditionIr::Select(_, cond) => cond.uses_map_table(name),
-            ConditionIr::Str(_) | ConditionIr::Ref(_) => false,
         }
     }
 }
@@ -621,37 +666,21 @@ impl GolangEmitter for ResourceIr {
                 output.text(")");
             }
             Self::If(cond, when_true, when_false) => {
-                let body = output.indent_with_options(IndentOptions {
+                // Ensure the ternary function is there...
+                context.insert_ternary();
+
+                let call = output.indent_with_options(IndentOptions {
                     indent: INDENT,
-                    leading: Some(
-                        "func() interface{} { // TODO: fix to appropriate value type".into(),
-                    ),
-                    trailing: Some("}()".into()),
+                    leading: Some(format!("{TERNARY}(").into()),
+                    trailing: Some(")".into()),
                     trailing_newline: false,
                 });
-                let case = body.indent_with_options(IndentOptions {
-                    indent: INDENT,
-                    leading: Some(
-                        format!(
-                            "if {cond} {{",
-                            cond = golang_identifier(cond, IdentifierKind::Unexported)
-                        )
-                        .into(),
-                    ),
-                    trailing: Some("} else {".into()),
-                    trailing_newline: true,
-                });
-                case.text("return ");
-                when_true.emit_golang(context, &case, Some(""));
-
-                let case = body.indent_with_options(IndentOptions {
-                    indent: INDENT,
-                    leading: None,
-                    trailing: Some("}".into()),
-                    trailing_newline: true,
-                });
-                case.text("return ");
-                when_false.emit_golang(context, &case, Some(""));
+                call.line(format!(
+                    "{cond},",
+                    cond = golang_identifier(cond, IdentifierKind::Unexported)
+                ));
+                when_true.emit_golang(context, &call, Some(","));
+                when_false.emit_golang(context, &call, Some(","));
             }
             Self::ImportValue(import) => {
                 output.text(format!("cdk.Fn_ImportValue(jsii.String({import:?}))"))

--- a/tests/end-to-end/simple/app.go
+++ b/tests/end-to-end/simple/app.go
@@ -92,7 +92,7 @@ func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *
 
 	stack := cdk.NewStack(scope, &id, &props.StackProps)
 
-	isUs := cdk.Fn_Select(jsii.Number("0"), cdk.Fn_Split(jsii.String("-"), stack.Region())) == jsii.String("us")
+	isUs := cdk.Fn_Select(jsii.Number(0), cdk.Fn_Split(jsii.String("-"), stack.Region())) == jsii.String("us")
 
 	isUsEast1 := stack.Region() == jsii.String("us-east-1")
 

--- a/tests/end-to-end/simple/app.go
+++ b/tests/end-to-end/simple/app.go
@@ -24,6 +24,8 @@ type NoctStack struct {
 	BucketArn interface{} // TODO: fix to appropriate type
 	/// The ARN of the SQS Queue
 	QueueArn interface{} // TODO: fix to appropriate type
+	/// Whether this is a large region or not
+	IsLarge interface{} // TODO: fix to appropriate type
 }
 
 func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *NoctStack {
@@ -122,13 +124,11 @@ func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *
 			Tags: &[]*cdk.CfnTag{
 				&cdk.CfnTag{
 					Key: jsii.String("FancyTag"),
-					Value: func() interface{} { // TODO: fix to appropriate value type
-						if isUsEast1 {
-							return cdk.Fn_Base64(table[jsii.String("Values")][jsii.String("String")])
-						} else {
-							return cdk.Fn_Base64(jsii.String("8CiMvAo="))
-						}
-					}(),
+					Value: ifCondition(
+						isUsEast1,
+						cdk.Fn_Base64(table[jsii.String("Values")][jsii.String("String")]),
+						cdk.Fn_Base64(jsii.String("8CiMvAo=")),
+					),
 				},
 			},
 		},
@@ -144,5 +144,21 @@ func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *
 		Stack: stack,
 		BucketArn: bucket.AttrArn(),
 		QueueArn: queue.Ref(),
+		IsLarge: ifCondition(
+			isLargeRegion,
+			jsii.Bool(true),
+			jsii.Bool(false),
+		),
 	}
+}
+
+/// ifCondition is a helper function that replicates the ternary
+/// operator that can be found in other languages. It is conceptually
+/// equivalent to writing `cond ? whenTrue : whenFalse`, meaning it
+/// returns `whenTrue` if `cond` is `true`, and `whenFalse` otherwise.
+func ifCondition[T any](cond bool, whenTrue T, whenFalse T) T {
+	if cond {
+		return whenTrue
+	}
+	return whenFalse
 }

--- a/tests/end-to-end/simple/app.ts
+++ b/tests/end-to-end/simple/app.ts
@@ -24,6 +24,10 @@ export class NoctStack extends cdk.Stack {
    * The ARN of the SQS Queue
    */
   public readonly queueArn;
+  /**
+   * Whether this is a large region or not
+   */
+  public readonly isLarge;
 
   public constructor(scope: cdk.App, id: string, props: NoctStackProps = {}) {
     super(scope, id, props);
@@ -128,5 +132,6 @@ export class NoctStack extends cdk.Stack {
       });
     }
     this.queueArn = queue.ref;
+    this.isLarge = isLargeRegion ? true : false;
   }
 }

--- a/tests/end-to-end/simple/template.yml
+++ b/tests/end-to-end/simple/template.yml
@@ -105,3 +105,8 @@ Outputs:
   QueueArn:
     Description: The ARN of the SQS Queue
     Value: !Ref Queue
+
+  IsLarge:
+    Description: Whether this is a large region or not
+    Value:
+      !If [IsLargeRegion, true, false]


### PR DESCRIPTION
Go does not have a ternary operator and if-else statements are not expressions, so one needs to compose an IIFE in order to emulate the semantics of the elvis operator (`?:`).

This can be pretty wordy, and requires being able to determine the appropriate value type locally, which is cumbersome. Fortunately, go generics can be used to let the Go compiler infer the correct type to use, and this in turns reduces the verbosity of the construct.

This introduces an `ifCondition` generic function to implement the ternary expression in a generic manner, which solves that problem.