### PR TITLE
fix: issues on cdk diff and changeset in Typescript conversion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           # Optional version of wasm-pack to install(eg. 'v0.9.1', 'latest')
           version: 'latest'
       - name: Build
-        run: wasm-pack build --target=nodejs --out-name=index
+        run: wasm-pack build --all-features --target=nodejs --out-name=index
       - name: Zip
         run: (cd pkg && zip -r ../wasm-pack.zip .)
       - name: Upload to release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,27 @@ jobs:
         with:
           RUSTTARGET: ${{ matrix.target }}
           ARCHIVE_TYPES: ${{ matrix.archive }}
+  release_wasm_pack:
+    name: release wasm_pack version
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - uses: actions/checkout@master
+      - uses: jetli/wasm-pack-action@v0.4.0
+        name: Install wasm-pack
+        with:
+          # Optional version of wasm-pack to install(eg. 'v0.9.1', 'latest')
+          version: 'latest'
+      - name: Build
+        run: wasm-pack build --target=nodejs --out-name=index
+      - name: Zip
+        run: (cd pkg && zip -r ../wasm-pack.zip .)
+      - name: Upload to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: *.zip
+          file_glob: true
+          tag: ${{ github.ref }}
+          overwrite: true
+          make_latest: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: *.zip
+          file: '*.zip'
           file_glob: true
           tag: ${{ github.ref }}
           overwrite: true

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules/
 
 # These are generated files:
 /src/specification/spec.rs
+/local/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "autocfg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
+checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.22",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -236,7 +236,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core 0.20.1",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -584,9 +584,9 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "serde"
-version = "1.0.165"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c939f902bb7d0ccc5bce4f03297e161543c2dcb30914faf032c2bd0b7a0d48fc"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
@@ -623,20 +623,20 @@ checksum = "794e44574226fc701e3be5c651feb7939038fc67fb73f6f4dd5c4ba90fd3be70"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.165"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eaae920e25fffe4019b75ff65e7660e72091e59dd204cb5849bbd6a3fd343d7"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
 dependencies = [
  "itoa",
  "ryu",
@@ -668,7 +668,7 @@ dependencies = [
  "darling 0.20.1",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -817,7 +817,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.25",
  "wasm-bindgen-shared",
 ]
 
@@ -839,7 +839,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.25",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,9 +585,9 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.165"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "c939f902bb7d0ccc5bce4f03297e161543c2dcb30914faf032c2bd0b7a0d48fc"
 dependencies = [
  "serde_derive",
 ]
@@ -624,9 +624,9 @@ checksum = "794e44574226fc701e3be5c651feb7939038fc67fb73f6f4dd5c4ba90fd3be70"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.165"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "6eaae920e25fffe4019b75ff65e7660e72091e59dd204cb5849bbd6a3fd343d7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,22 +132,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.8"
+version = "4.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9394150f5b4273a1763355bd1c2ec54cc5a2593f790587bcd6b2c947cfa9211"
+checksum = "384e169cc618c613d5e3ca6404dda77a8685a63e08660dcc64abaf7da7cb0c7a"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.8"
+version = "4.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a78fbdd3cc2914ddf37ba444114bc7765bbdcb55ec9cbe6fa054f0137400717"
+checksum = "ef137bbe35aab78bdb468ccfba75a5f4d8321ae011d34063770780545176af2d"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
  "clap_lex",
  "once_cell",
  "strsim",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.22"
+version = "0.9.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452e67b9c20c37fa79df53201dc03839651086ed9bbe92b3ca585ca9fdaa7d85"
+checksum = "da6075b41c7e3b079e5f246eb6094a44850d3a4c25a67c581c80796c80134012"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,18 +132,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.11"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
+checksum = "3eab9e8ceb9afdade1ab3f0fd8dbce5b1b2f468ad653baf10e771781b2b67b73"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.11"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
+checksum = "9f2763db829349bf00cfc06251268865ed4363b93a943174f638daf3ecdba2cd"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,18 +132,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.10"
+version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384e169cc618c613d5e3ca6404dda77a8685a63e08660dcc64abaf7da7cb0c7a"
+checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.10"
+version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef137bbe35aab78bdb468ccfba75a5f4d8321ae011d34063770780545176af2d"
+checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ wasm-bindgen = "^0.2.87"
 [build-dependencies]
 phf_codegen = "^0.11.2"
 serde = { version = "^1.0.165", features = ["derive"] }
-serde_json = "^1.0.100"
+serde_json = "^1.0.103"
 serde_with = "^3.0.0"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ homepage = "https://github.com/iph/noctilucent#readme"
 default = ["typescript"]
 typescript = []
 golang = []
+java = []
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 anyhow = "^1.0.71"
 base64 = "^0.21.2"
-clap = { version = "^4.3.8", features = ["cargo"] }
+clap = { version = "^4.3.10", features = ["cargo"] }
 indexmap = { version = "^2.0.0", features = ["serde"] }
 nom = "^7.1.3"
 numberkit = "^0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 anyhow = "^1.0.71"
 base64 = "^0.21.2"
-clap = { version = "^4.3.10", features = ["cargo"] }
+clap = { version = "^4.3.11", features = ["cargo"] }
 indexmap = { version = "^2.0.0", features = ["serde"] }
 nom = "^7.1.3"
 numberkit = "^0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 anyhow = "^1.0.71"
 base64 = "^0.21.2"
-clap = { version = "^4.3.11", features = ["cargo"] }
+clap = { version = "^4.3.12", features = ["cargo"] }
 indexmap = { version = "^2.0.0", features = ["serde"] }
 nom = "^7.1.3"
 numberkit = "^0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ indexmap = { version = "^2.0.0", features = ["serde"] }
 nom = "^7.1.3"
 numberkit = "^0.1.0"
 phf = "^0.11.2"
-serde = { version = "^1.0.164", features = ["derive"] }
+serde = { version = "^1.0.165", features = ["derive"] }
 serde-enum-str = "^0.3.2"
 serde_with = "^3.0.0"
 serde_yaml = "^0.9.22"
@@ -43,7 +43,7 @@ wasm-bindgen = "^0.2.87"
 
 [build-dependencies]
 phf_codegen = "^0.11.2"
-serde = { version = "^1.0.164", features = ["derive"] }
+serde = { version = "^1.0.165", features = ["derive"] }
 serde_json = "^1.0.99"
 serde_with = "^3.0.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ java = []
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-anyhow = "^1.0.71"
+anyhow = "^1.0.72"
 base64 = "^0.21.2"
 clap = { version = "^4.3.12", features = ["cargo"] }
 indexmap = { version = "^2.0.0", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ phf = "^0.11.2"
 serde = { version = "^1.0.165", features = ["derive"] }
 serde-enum-str = "^0.3.2"
 serde_with = "^3.0.0"
-serde_yaml = "^0.9.22"
+serde_yaml = "^0.9.23"
 topological-sort = "^0.2.2"
 voca_rs = "^1.15.2"
 wasm-bindgen = "^0.2.87"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ wasm-bindgen = "^0.2.87"
 [build-dependencies]
 phf_codegen = "^0.11.2"
 serde = { version = "^1.0.165", features = ["derive"] }
-serde_json = "^1.0.99"
+serde_json = "^1.0.100"
 serde_with = "^3.0.0"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Name         | Enabled by default | Description
 -------------|:------------------:|---------------------------------------------
 `typescript` | :heavy_check_mark: | Enables support for TypeScript output
 `golang`     |                    | Enables support for Go output
+`java`       |                    | Enables support for Java output
 
 You can enable experimental languages (not enabled by default) by enabling the relevant feature:
 ```console

--- a/build.rs
+++ b/build.rs
@@ -55,13 +55,19 @@ fn main() -> io::Result<()> {
     }
 
     // Install some TypeScript stuff in the right places for IDE comfort. Silently ignore if failing...
-    let npm_exit = Command::new("npm")
+    match Command::new("npm")
         .args(["install", "--no-save", "aws-cdk-lib", "@types/node"])
         .current_dir("tests/end-to-end")
         .status()
-        .unwrap();
-    if !npm_exit.success() {
-        eprintln!("npm install failed with {npm_exit:?}");
+    {
+        Ok(npm_exit) => {
+            if !npm_exit.success() {
+                eprintln!("npm install failed with {npm_exit:?}");
+            }
+        }
+        Err(cause) => {
+            eprintln!("npm install failed with {cause:?}");
+        }
     }
 
     Ok(())

--- a/src/ir/README.md
+++ b/src/ir/README.md
@@ -1,0 +1,31 @@
+# `noctilucent::ir`
+
+This module contains the Intermediate Representation (IR) `noctilucent` uses in
+order to facilitate translating CloudFormation templates into AWS CDK
+applications. The IR data structures are obtained by transforming Parse Trees
+produced by the `noctilucent::parser` module.
+
+The conversion is informed by a copy of the [AWS CloudFormation Resource
+Specification][cfnspec] document, which provides information about properties
+accepted (and attributes returned) by the various supported CloudFormation
+Resource Types.
+
+The IR is composed of various kinds of "instructions" (which can also be
+thought about as declarations), which will compose the final AWS CDK
+application:
+
+- `ImportInstruction` convey information about modules that need importing in
+  order to bring the necessary AWS CDK constructs in-scope;
+- `ResourceInstruction` models a single CloudFormation Resource construct
+  instanciation, listing the provided properties and their associated values;
+- `OutputInstruction` represents properties exposed by the generated AWS CDK
+  Stack class, optionally bound to a CloudFormation Output object;
+- etc...
+
+The IR is topologically sorted so that `noctilucent::synthesizer` can process
+instructions in the order they are provided, resulting in a program with
+correctly ordered declarations (while CloudFormation templates allow resources
+to be declared in an arbitrary order, AWS CDK applications naturally require
+variables to be declared before they can be referenced).
+
+[cfnspec]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html

--- a/src/ir/importer/mod.rs
+++ b/src/ir/importer/mod.rs
@@ -27,6 +27,12 @@ impl ImportInstruction {
                         .map(|(service, resource)| (organization, service, resource))
                 }) {
                 triple
+            // In CloudFormation, custom typenames are always of the form `Custom::<Resource>`
+            } else if let Some(double) =
+                type_name.split_once("::")
+                    .map(|(custom, resource)| (custom, resource, ""))
+            {
+                double
             } else {
                 return Err(TransmuteError::new(format!(
                     "invalid resource type name: {type_name}"
@@ -34,7 +40,7 @@ impl ImportInstruction {
             };
 
             // These must always exist.
-            // In CloudFormation, typenames are always of the form `<Organization>::<Service>::<Resource>
+            // In CloudFormation, typenames are always of the form `<Organization>::<Service>::<Resource>`
             let organization = organization.to_ascii_lowercase();
             let service = service.to_ascii_lowercase();
             type_names.insert(TypeName {

--- a/src/ir/resources/mod.rs
+++ b/src/ir/resources/mod.rs
@@ -79,18 +79,18 @@ impl<'t> ResourceTranslator<'t> {
                 if let Structure::Simple(simple_type) = &self.complexity {
                     return match simple_type {
                         CfnType::Boolean => {
-                            Ok(ResourceIr::Bool(s.parse().map_err(|cause| {
-                                TransmuteError::new(format!("{cause}"))
+                            Ok(ResourceIr::Bool(s.to_lowercase().parse().map_err(|cause| {
+                                TransmuteError::new(format!("{cause} {s}"))
                             })?))
                         }
                         CfnType::Integer => {
                             Ok(ResourceIr::Number(s.parse().map_err(|cause| {
-                                TransmuteError::new(format!("{cause}"))
+                                TransmuteError::new(format!("{cause} {s}"))
                             })?))
                         }
                         CfnType::Double => {
                             Ok(ResourceIr::Number(s.parse().map_err(|cause| {
-                                TransmuteError::new(format!("{cause}"))
+                                TransmuteError::new(format!("{cause} {s}"))
                             })?))
                         }
                         &_ => Ok(ResourceIr::String(s)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub mod wasm {
     /// Transforms the provided template into a CDK application in the specified
     /// language.
     #[wasm_bindgen]
-    pub fn transmute(template: &str, language: &str) -> Result<String, JsError> {
+    pub fn transmute(template: &str, language: &str, stack_name: &str) -> Result<String, JsError> {
         let cfn_tree: CloudformationParseTree = serde_yaml::from_str(template)?;
         let ir = crate::ir::CloudformationProgramIr::from(cfn_tree)?;
         let mut output = Vec::new();
@@ -73,7 +73,7 @@ pub mod wasm {
             unsupported => panic!("unsupported language: {}", unsupported),
         };
 
-        ir.synthesize(synthesizer.as_ref(), &mut output)?;
+        ir.synthesize(synthesizer.as_ref(), &mut output, stack_name)?;
 
         String::from_utf8(output).map_err(Into::into)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,14 @@ fn main() -> anyhow::Result<()> {
                 .value_parser(targets)
                 .action(ArgAction::Set),
         )
+        .arg(
+            Arg::new("stack-name")
+                .help("Sets the name of the stack")
+                .required(false)
+                .long("stack-name")
+                .short('s')
+                .action(ArgAction::Set),
+        )
         .get_matches();
 
     let cfn_tree: CloudformationParseTree = {
@@ -83,7 +91,12 @@ fn main() -> anyhow::Result<()> {
         unsupported => panic!("unsupported language: {}", unsupported),
     };
 
-    ir.synthesize(synthesizer.as_ref(), &mut output)?;
+    let stack_name = matches
+        .get_one::<String>("stack-name")
+        .map(String::as_str)
+        .unwrap_or("NoctStack");
+
+    ir.synthesize(synthesizer.as_ref(), &mut output, stack_name)?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use noctilucent::CloudformationParseTree;
 use std::{fs, io};
 
 // Ensure at least one target language is enabled...
-#[cfg(not(any(feature = "typescript", feature = "golang")))]
+#[cfg(not(any(feature = "typescript", feature = "golang", feature = "java")))]
 compile_error!("At least one language target feature must be enabled!");
 
 fn main() -> anyhow::Result<()> {
@@ -14,6 +14,8 @@ fn main() -> anyhow::Result<()> {
         "typescript",
         #[cfg(feature = "golang")]
         "go",
+        #[cfg(feature = "java")]
+        "java",
     ];
 
     let matches = Command::new(env!("CARGO_BIN_NAME"))
@@ -76,6 +78,8 @@ fn main() -> anyhow::Result<()> {
         "typescript" => Box::new(Typescript {}),
         #[cfg(feature = "golang")]
         "go" => Box::<Golang>::default(),
+        #[cfg(feature = "java")]
+        "java" => Box::<Java>::default(),
         unsupported => panic!("unsupported language: {}", unsupported),
     };
 

--- a/src/parser/README.md
+++ b/src/parser/README.md
@@ -1,0 +1,29 @@
+# `noctilucent::parser`
+
+This module is responsible for parsing AWS CloudFormation YAML (and JSON)
+templates to a very immediate rust representation of it. The parsing logic is
+implemented using the [`serde` crate][serde] (a part of it is derived, while
+some special cases are hand-coded, typically to accommodate for specific
+CloudFormation syntax allowances). Naturally, the
+[`serde_yaml` crate][serde_yaml] produces the YAML/JSON specific parser
+front-end.
+
+The [Template anatomy][cfn-template-anatomy] page in the CloudFormation user
+guide describes the elements and schema of the various components of a
+CloudFormation template document. It is worth noting however that CloudFormation
+is relatively lenient in how it parses and validates templates:
+
+- it is often legal to pass a single, scalar value in a place where an array is
+  expected, and CloudFormation usually interprets this as synonymous to a single
+  valued array containing that value;
+- CloudFormation is able to transparently convert data between types as is
+  necessary, as long as the conversion is straight-forward (e.g: the string
+  `'1337'` can trivially be converted to the integer `1337`, and vice-versa);
+
+This leniency explains most of the complexity and hand-written parts of the
+parser module, which is otherwise a straight-forward translation of the schema
+described by the [Template anatomy][cfn-template-anatomy] documentation.
+
+[serde]: https://docs.rs/serde/latest/serde/
+[serde_yaml]: https://docs.rs/serde_yaml/latest/serde_yaml/
+[cfn-template-anatomy]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html

--- a/src/synthesizer/README.md
+++ b/src/synthesizer/README.md
@@ -1,0 +1,16 @@
+# `noctilucent::synthesizer`
+
+This module contains the synthesizers for the various supported output
+languages. They transform the Intermediate Representation (IR) produced by the
+`noctilucent::ir` module into AWS CDK applications in a particular language.
+
+Each target language is exposed as a specific Cargo feature (`typescript`,
+`golang`, ...), so that users can build `noctilucent` binaries tailored down to
+their specific use-cases, reducing compilation time and binary size. Languages
+considered "stable" are however enabled by default, while "experimental" targets
+are opt-in.
+
+The `Synthesizer` API is very simple, reciving a CloudFormation Template IR
+object, and a `Writer` to which the generated code should be written. The
+`noctilucent::code` module provides assistance for generating code, in
+particular for maintaining correct indentation levels.

--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -39,7 +39,12 @@ impl Default for Golang {
 }
 
 impl Synthesizer for Golang {
-    fn synthesize(&self, ir: CloudformationProgramIr, into: &mut dyn io::Write) -> io::Result<()> {
+    fn synthesize(
+        &self,
+        ir: CloudformationProgramIr,
+        into: &mut dyn io::Write,
+        stack_name: &str,
+    ) -> io::Result<()> {
         let code = CodeBuffer::default();
 
         code.line(format!("package {}", self.package_name));
@@ -64,7 +69,7 @@ impl Synthesizer for Golang {
 
         let props = code.indent_with_options(IndentOptions {
             indent: INDENT,
-            leading: Some("type NoctStackProps struct {".into()),
+            leading: Some(format!("type {}Props struct {{", stack_name).into()),
             trailing: Some("}".into()),
             trailing_newline: true,
         });
@@ -82,7 +87,7 @@ impl Synthesizer for Golang {
         }
         let class = code.indent_with_options(IndentOptions {
             indent: INDENT,
-            leading: Some("type NoctStack struct {".into()),
+            leading: Some(format!("type {} struct {{", stack_name).into()),
             trailing: Some("}".into()),
             trailing_newline: true,
         });
@@ -98,9 +103,15 @@ impl Synthesizer for Golang {
         }
         code.newline();
 
-        let ctor = code.indent_with_options(IndentOptions{
+        let ctor = code.indent_with_options(IndentOptions {
             indent: INDENT,
-            leading: Some("func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *NoctStack {".into()),
+            leading: Some(
+                format!(
+                    "func New{}(scope constructs.Construct, id string, props {}Props) *{} {{",
+                    stack_name, stack_name, stack_name
+                )
+                .into(),
+            ),
             trailing: Some("}".into()),
             trailing_newline: true,
         });
@@ -270,7 +281,7 @@ impl Synthesizer for Golang {
 
         let fields = ctor.indent_with_options(IndentOptions {
             indent: INDENT,
-            leading: Some("return &NoctStack{".into()),
+            leading: Some(format!("return &{}{{", stack_name).into()),
             trailing: Some("}".into()),
             trailing_newline: true,
         });

--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -616,9 +616,10 @@ impl GolangEmitter for ResourceIr {
                             "Tag" => "&cdk.CfnTag{".into(),
                             name => format!("&{name}/* FIXME */{{").into(),
                         },
-                        Structure::Simple(cfn) => {
-                            unreachable!("object with simple structure ({:?})", cfn)
-                        }
+                        Structure::Simple(simple) => match simple {
+                            CfnType::Json => "interface{}{".into(),
+                            _ => unreachable!("object with simple structure ({:?})", simple)
+                        },
                     }),
                     trailing: Some("}".into()),
                     trailing_newline: false,

--- a/src/synthesizer/java/mod.rs
+++ b/src/synthesizer/java/mod.rs
@@ -1,0 +1,732 @@
+use super::Synthesizer;
+use crate::code::{CodeBuffer, IndentOptions};
+use crate::ir::conditions::ConditionIr;
+use crate::ir::importer::ImportInstruction;
+use crate::ir::outputs::OutputInstruction;
+use crate::ir::reference::{Origin, PseudoParameter, Reference};
+use crate::ir::resources::ResourceIr;
+use crate::ir::CloudformationProgramIr;
+use crate::parser::lookup_table::MappingInnerValue;
+use crate::specification::{CfnType, Structure};
+use std::borrow::Cow;
+use std::collections::LinkedList;
+use std::io;
+use std::rc::Rc;
+use voca_rs::case::{camel_case, pascal_case};
+
+const INDENT: Cow<'static, str> = Cow::Borrowed("  ");
+const STACK_NAME: Cow<'static, str> = Cow::Borrowed("NoctStack");
+
+macro_rules! fill {
+    ($code:ident; $leading:expr; $($lines:expr),* ; $trailing:expr) => {
+        {
+            let _class = $code.indent_with_options(IndentOptions {
+                indent: INDENT,
+                leading: Some($leading.into()),
+                trailing: Some($trailing.into()),
+                trailing_newline: true,
+            });
+
+            $(_class.line(format!($lines));)*
+        }
+    };
+}
+
+macro_rules! br {
+    ($prefix: expr, $str:expr) => {
+        format!("{}\n{INDENT}{}", $prefix, $str)
+    };
+}
+
+pub struct Java {
+    package_name: String,
+}
+
+impl Java {
+    pub fn new(package_name: impl Into<String>) -> Self {
+        Self {
+            package_name: package_name.into(),
+        }
+    }
+
+    //noinspection ALL
+    fn write_header(&self, code: &CodeBuffer) {
+        code.line(format!("package {};", self.package_name));
+
+        // base imports
+        code.newline();
+        code.line("import software.constructs.Construct;");
+        code.newline();
+        code.line("import java.util.*;");
+        code.line("import java.util.stream.Collectors;");
+        code.line("import software.amazon.awscdk.*;");
+        code.line("import software.amazon.awscdk.App;");
+        code.line("import software.amazon.awscdk.CfnMapping;");
+        code.line("import software.amazon.awscdk.CfnTag;");
+        code.line("import software.amazon.awscdk.Stack;");
+        code.line("import software.amazon.awscdk.StackProps;");
+    }
+
+    fn write_app(&self, writer: &CodeBuffer, description: &Option<String>) {
+        let app_name = "NoctApp";
+        let class = &writer.indent_with_options(IndentOptions {
+            indent: INDENT,
+            leading: Some(format!("public class {} {{", app_name).into()),
+            trailing: Some("}".into()),
+            trailing_newline: true,
+        });
+        let main = &class.indent_with_options(IndentOptions {
+            indent: INDENT,
+            leading: Some("public static void main(final String[] args) {".into()),
+            trailing: Some("}".into()),
+            trailing_newline: true,
+        });
+        main.line(format!("App app = new App();"));
+        let stack_prop = main.indent_with_options(IndentOptions {
+            indent: INDENT,
+            leading: Some("StackProps props = StackProps.builder()".into()),
+            trailing: Some(format!("{INDENT}.build();").into()),
+            trailing_newline: true,
+        });
+        match description {
+            Some(desc) => stack_prop.line(format!(
+                ".description(\"{}\")",
+                desc.replace("\n", "\" + \n  \"")
+            )),
+            None => stack_prop.line("\"\""),
+        };
+        main.line(format!(
+            "new {}(app, \"MyProjectStack\", props);",
+            STACK_NAME
+        ));
+        main.line("app.synth();");
+    }
+
+    fn write_helpers(&self, code: &CodeBuffer) {
+        const UTILS: &str = "class GenericList<T> extends LinkedList<T> {
+  public GenericList<T> extend(final T object) {
+    this.addLast(object);
+    return this;
+  }
+
+  public GenericList<T> extend(final List<T> collection) {
+    this.addAll(collection);
+    return this;
+  }
+}
+
+class GenericMap<T, S> extends HashMap<T, S> {
+  public GenericMap<T, S> extend(final T key, final S value) {
+    this.put(key, value);
+    return this;
+  }
+
+  public List<CfnTag> getTags() {
+    final List<CfnTag> tags = new LinkedList<>();
+    for (Map.Entry<T, S> entry : this.entrySet()) {
+      tags.add(
+          CfnTag.builder()
+              .key(String.valueOf(entry.getKey()))
+              .value(String.valueOf(entry.getValue()))
+              .build());
+    }
+    return tags;
+  }
+}
+
+class Mapping<T> {
+  private final String name;
+  private final Construct scope;
+  private final Map<String, Map<String, T>> inner = new TreeMap<>();
+
+  public Mapping(Construct scope, String name) {
+    this.name = name;
+    this.scope = scope;
+  }
+
+  public Mapping<T> put(String primaryKey, String secondaryKey, T value) {
+    final Map<String, T> map = inner.getOrDefault(primaryKey, new TreeMap<>());
+    map.put(secondaryKey, value);
+    inner.put(primaryKey, map);
+    return this;
+  }
+
+  public CfnMapping get() {
+    return CfnMapping.Builder.create(this.scope, this.name).mapping(this.inner).build();
+  }
+}
+";
+        code.line(UTILS);
+    }
+
+    fn write_mappings(ir: &CloudformationProgramIr, map: &Rc<CodeBuffer>) {
+        map.line("// Start Mapping section");
+        for mapping in &ir.mappings {
+            let mut mapping_init = false;
+            let map_name = name(&mapping.name);
+
+            for (outer_key, inner) in mapping.map.iter() {
+                let values: Vec<&MappingInnerValue> = inner.values().collect();
+                let inner_type: &str = check_type(values);
+
+                for (inner_key, value) in inner.iter() {
+                    if !mapping_init {
+                        map.line(format!(
+                            "final Mapping<{inner_type}> {map_name} = new Mapping<>(this, \"{}\");",
+                            &mapping.name
+                        ));
+                        mapping_init = true;
+                    }
+                    map.text(format!("{map_name}.put(\"{outer_key}\", \"{inner_key}\", "));
+
+                    match value {
+                        MappingInnerValue::Bool(bool) => {
+                            map.text(format!("{}", if *bool { "true" } else { "false" }))
+                        }
+                        MappingInnerValue::Number(num) => map.text(format!("{num}")),
+                        MappingInnerValue::Float(num) => map.text(format!("{num}")),
+                        MappingInnerValue::String(str) => map.text(format!("{str:?}")),
+                        MappingInnerValue::List(items) => {
+                            let list = map.indent_with_options(IndentOptions {
+                                indent: INDENT,
+                                leading: None,
+                                trailing: None,
+                                trailing_newline: false,
+                            });
+                            list.text(format!("new GenericList<String>()"));
+                            for item in items {
+                                list.text(br!("", format!(".extend({item:?})")));
+                            }
+                        }
+                    }
+                    map.line(");")
+                }
+            }
+            map.line(format!(
+                "final CfnMapping {map_name}CfnMapping = {map_name}.get();",
+            ));
+            map.newline();
+        }
+    }
+
+    fn write_parameters(ir: &CloudformationProgramIr, writer: &Rc<CodeBuffer>) {
+        for input in &ir.constructor.inputs {
+            let name = camel_case(&input.name);
+            writer.line(format!(
+                "CfnParameter {name} = CfnParameter.Builder.create(this, \"{}\")",
+                &input.name
+            ));
+            match &input.description {
+                Some(descr) => writer
+                    .indent(INDENT)
+                    .line(format!(".description(\"{}\")", descr)),
+                None => {}
+            };
+            match &input.default_value {
+                Some(val) => writer.indent(INDENT).line(format!(
+                    ".defaultValue({}.valueOf(\"{}\"))",
+                    &input.constructor_type, val
+                )),
+                None => {}
+            };
+            writer.line(format!("{INDENT}.build();"))
+        }
+    }
+
+    fn write_resources(ir: &CloudformationProgramIr, writer: &Rc<CodeBuffer>) {
+        for resource in &ir.resources {
+            let class = resource.resource_type.type_name();
+            let res_name = &resource.name;
+            writer.newline();
+            let res_info = writer.indent_with_options(IndentOptions {
+                indent: INDENT,
+                leading: Some(
+                    format!(
+                        "Cfn{class} {} = Cfn{class}.Builder.create(this, \"{res_name}\")",
+                        name(&res_name)
+                    )
+                    .into(),
+                ),
+                trailing: Some(format!("{INDENT}.build();").into()),
+                trailing_newline: true,
+            });
+            let properties = res_info.indent_with_options(IndentOptions {
+                indent: INDENT,
+                leading: None,
+                trailing: None,
+                trailing_newline: false,
+            });
+            for (key, value) in &resource.properties {
+                let property = camel_case(key.as_str());
+                let value = emit_java(value.clone(), None);
+                properties.line(format!(".{property}({value})"));
+            }
+            writer.newline();
+        }
+    }
+
+    fn write_methods(class: Rc<CodeBuffer>) {
+        class.newline();
+
+        let static_helper = class.indent_with_options(IndentOptions {
+            indent: INDENT,
+            leading: Some("public static <T> List<String> get(final List<T> input) {".into()),
+            trailing: Some("}".into()),
+            trailing_newline: true,
+        });
+        static_helper
+            .line("return input.stream().map(String::valueOf).collect(Collectors.toList());");
+    }
+
+    fn write_conditions(ir: &CloudformationProgramIr, writer: &Rc<CodeBuffer>) {
+        for condition in &ir.conditions {
+            let name = &*condition.name;
+            let val = &condition.value;
+            writer.line(
+                format!("CfnCondition {} = CfnCondition.Builder.create(this, \"{}\").expression({}).build();",
+                        camel_case(name), name, emit_conditions(val.clone()))
+            );
+        }
+    }
+
+    fn write_outputs(outputs: LinkedList<String>, writer: &Rc<CodeBuffer>) {
+        for output in outputs {
+            writer.line(output)
+        }
+    }
+
+    fn get_outputs(ir: &CloudformationProgramIr) -> (LinkedList<String>, LinkedList<String>) {
+        let mut output_names: LinkedList<String> = LinkedList::new();
+        let mut output_definitions: LinkedList<String> = LinkedList::new();
+        for output in &ir.outputs {
+            let (key, value) = emit_output(output);
+            output_names.push_back(key);
+            output_definitions.push_back(value);
+        }
+        (output_names, output_definitions)
+    }
+
+    fn write_field_logic(writer: &Rc<CodeBuffer>, names: LinkedList<String>) {
+        if names.is_empty() {
+            return;
+        }
+        writer.line(format!(
+            "private CfnOutput {};\n",
+            names.iter().cloned().collect::<Vec<String>>().join(", ")
+        ));
+
+        for name in names {
+            let indented = writer.indent_with_options(IndentOptions {
+                indent: INDENT,
+                leading: Some(format!("public CfnOutput get{}() {{", pascal_case(&*name)).into()),
+                trailing: Some("}".into()),
+                trailing_newline: true,
+            });
+            indented.line(format!("return this.{};", name));
+        }
+    }
+}
+
+fn get_type(value: &MappingInnerValue) -> &str {
+    let inner_type = match value {
+        MappingInnerValue::Bool(_) => "Boolean",
+        MappingInnerValue::Number(_) => "Integer",
+        MappingInnerValue::Float(_) => "Double",
+        MappingInnerValue::String(_) => "String",
+        MappingInnerValue::List(_) => "List<String>",
+    };
+    inner_type
+}
+
+fn check_type(values: Vec<&MappingInnerValue>) -> &str {
+    let mut found_type = "Object";
+    let mut current_type;
+    for (index, value) in values.iter().enumerate() {
+        current_type = get_type(value);
+        if index < 1 {
+            found_type = current_type;
+        }
+        if !current_type.eq(found_type) {
+            return "Object";
+        }
+    }
+    return found_type;
+}
+
+impl Default for Java {
+    fn default() -> Self {
+        Self::new("com.acme.test.simple")
+    }
+}
+
+impl Synthesizer for Java {
+    fn synthesize(&self, ir: CloudformationProgramIr, into: &mut dyn io::Write) -> io::Result<()> {
+        let code = CodeBuffer::default();
+
+        self.write_header(&code);
+
+        for import in &ir.imports {
+            code.line(import.to_java());
+        }
+        code.newline();
+
+        self.write_app(&code, &ir.description);
+
+        fill!(code; format!("\ninterface {}Props extends StackProps {{", STACK_NAME);; "}" );
+
+        let class = code.indent_with_options(IndentOptions {
+            indent: INDENT,
+            leading: Some(format!("\nclass {} extends Stack {{", STACK_NAME).into()),
+            trailing: Some("}".into()),
+            trailing_newline: true,
+        });
+
+        let (output_names, output_definitions) = Self::get_outputs(&ir);
+        Self::write_field_logic(&class, output_names);
+
+        fill!(class;
+            format!("public {}(final Construct scope, final String id) {{", STACK_NAME);
+            "super(scope, id, null);";
+            "}" );
+
+        let definitions = class.indent_with_options(IndentOptions {
+            indent: INDENT,
+            leading: Some(
+                format!(
+                    "public {}(final Construct scope, final String id, final StackProps props) {{",
+                    STACK_NAME
+                )
+                .into(),
+            ),
+            trailing: Some("}".into()),
+            trailing_newline: true,
+        });
+        definitions.line("super(scope, id, props);");
+
+        Self::write_mappings(&ir, &definitions.clone());
+        Self::write_parameters(&ir, &definitions);
+        Self::write_conditions(&ir, &definitions);
+        Self::write_resources(&ir, &definitions);
+        Self::write_outputs(output_definitions, &definitions);
+
+        Self::write_methods(class);
+        self.write_helpers(&code);
+
+        code.write(into)
+    }
+}
+
+impl ImportInstruction {
+    fn to_java(&self) -> String {
+        let mut parts: Vec<Cow<str>> = vec![match self.path[0].as_str() {
+            "aws-cdk-lib" => "software.amazon.awscdk.services".into(),
+            other => other.into(),
+        }];
+        parts.extend(self.path[1..].iter().map(|item| {
+            item.chars()
+                .filter(|ch| ch.is_alphanumeric())
+                .collect::<String>()
+                .into()
+        }));
+
+        let module = parts
+            .iter()
+            .take(parts.len() - 1)
+            .map(|part| part.to_string())
+            .collect::<Vec<_>>()
+            .join(".");
+        if !module.is_empty() {
+            format!(
+                "import {module}.{name}.*;",
+                module = module,
+                name = self.name,
+            )
+        } else {
+            "".to_string()
+        }
+    }
+}
+
+fn match_cfn_type(input: &CfnType) -> String {
+    String::from(match input {
+        CfnType::Boolean => "Boolean",
+        CfnType::Double => "Double",
+        CfnType::Integer => "Integer",
+        CfnType::Long => "Long",
+        CfnType::Json => "JsonNode jsonNode = objectMapper.readTree(jsonString);",
+        CfnType::String => "String",
+        CfnType::Timestamp => "/*TODO*/",
+    })
+}
+
+fn emit_conditions(condition: ConditionIr) -> String {
+    match condition {
+        ConditionIr::Ref(reference) => emit_reference(reference),
+        ConditionIr::Str(str) => format!("{str:?}"),
+        ConditionIr::Condition(x) => camel_case(&*x),
+        ConditionIr::And(list) => {
+            format!("Fn.conditionAnd({:?})", get_condition(list))
+        }
+        ConditionIr::Or(list) => {
+            format!("Fn.conditionOr({:?})", get_condition(list))
+        }
+        ConditionIr::Not(cond) => {
+            format!("Fn.conditionOr({:?})", emit_conditions(*cond))
+        }
+        ConditionIr::Equals(lhs, rhs) => {
+            format!(
+                "Fn.conditionEquals({}, {})",
+                emit_conditions(*lhs),
+                emit_conditions(*rhs)
+            )
+        }
+        ConditionIr::Map(_, tlk, slk) => {
+            format!(
+                "Fn.map({}, {})",
+                emit_conditions(*tlk),
+                emit_conditions(*slk)
+            )
+        }
+        ConditionIr::Split(sep, str) => {
+            format!("Fn.split({sep:?}, {})", emit_conditions(*str))
+        }
+        ConditionIr::Select(index, str) => {
+            format!("Fn.select({index:?}, get({}))", emit_conditions(*str))
+        }
+    }
+}
+
+fn emit_reference(reference: Reference) -> String {
+    let origin = reference.origin;
+    let name = reference.name;
+    match origin {
+        Origin::LogicalId { .. } => format!("\"{name}\""),
+        Origin::GetAttribute { attribute, .. } => format!("Fn.getAtt(\"{name}\", \"{attribute}\")"),
+        Origin::PseudoParameter(param) => get_pseudo_param(param),
+        Origin::Parameter => format!("{}", camel_case(&*name)),
+        Origin::Condition => name,
+    }
+}
+
+fn get_pseudo_param(param: PseudoParameter) -> String {
+    match param {
+        PseudoParameter::Partition => "this.getPartition()",
+        PseudoParameter::Region => "this.getRegion()",
+        PseudoParameter::StackId => "this.getStackId()",
+        PseudoParameter::StackName => "this.getStackName()",
+        PseudoParameter::URLSuffix => "this.getUrlSuffix()",
+        PseudoParameter::AccountId => "this.getAccount()",
+        PseudoParameter::NotificationArns => "this.getNotificationArns()",
+    }
+    .into()
+}
+
+fn get_condition(list: Vec<ConditionIr>) -> String {
+    let mut res = format!("");
+    for (idx, cond) in list.iter().enumerate() {
+        if idx == list.len() {
+            res = format!("{res} {}", emit_conditions(cond.clone()))
+        } else {
+            res = format!("{res} {},", emit_conditions(cond.clone()))
+        }
+    }
+    res
+}
+
+fn emit_output(output: &OutputInstruction) -> (String, String) {
+    let name = output.name.clone();
+    let var_name = camel_case(&*name);
+    let mut res = format!(
+        "{} = CfnOutput.Builder.create(this, \"{}\")",
+        var_name, name
+    );
+
+    res = br!(
+        res,
+        format!(
+            ".value(String.valueOf({}))",
+            emit_java(output.value.clone(), None)
+        )
+    );
+
+    if let Some(descr) = output.description.clone() {
+        res = br!(res, format!(".description(\"{descr}\")"));
+    }
+    if let Some(export_name) = output.export.clone() {
+        res = br!(
+            res,
+            format!(".exportName({})", emit_java(export_name, None))
+        );
+    }
+
+    if let Some(condition) = &output.condition {
+        res = br!(res, format!(".condition({})", camel_case(condition)));
+    }
+
+    res = format!("{res}{INDENT}.build();");
+    (var_name, res)
+}
+
+fn emit_java(this: ResourceIr, trailer: Option<&str>) -> String {
+    match this {
+        // Base cases
+        ResourceIr::Null => "null".to_string(),
+        ResourceIr::Bool(bool) => bool.to_string(),
+        ResourceIr::Number(number) => format!("{number}"),
+        ResourceIr::Double(number) => format!("{number}"),
+        ResourceIr::String(text) => {
+            if text.is_empty() {
+                format!("/* validate FIXME */ \"\"")
+            } else {
+                format!("\"{text}\"")
+            }
+        }
+        ResourceIr::ImportValue(text) => format!("\"{text}\""),
+
+        ResourceIr::Object(structure, index_map) => match structure {
+            Structure::Composite(_) => {
+                let mut res = format!("new GenericMap<String, Object>()");
+                for (key, value) in &index_map {
+                    let element = emit_java((*value).clone(), None);
+                    if key.eq_ignore_ascii_case("Key") {
+                        res = br!(res, format!(".extend({}", element))
+                    }
+                    if key.eq_ignore_ascii_case("Value") {
+                        res = format!("{res},{})", element)
+                    }
+                }
+                br!(res, ".getTags()")
+            }
+
+            Structure::Simple(cfn_type) => {
+                let mut res = format!("new GenericMap<String, {}>()", match_cfn_type(&cfn_type));
+                for (key, value) in &index_map {
+                    let element = emit_java((*value).clone(), None);
+                    res = br!(res, format!(".extend({}, {})", key, element));
+                }
+                res
+            }
+        },
+
+        ResourceIr::Array(structure, vect) => {
+            let mut res: String;
+            match structure {
+                Structure::Composite(_) => {
+                    res = format!("new GenericList<CfnTag>()");
+                }
+
+                Structure::Simple(cfn_type) => {
+                    let current_type = match_cfn_type;
+                    res = format!("new GenericList<{}>()", current_type(&cfn_type));
+                }
+            }
+            for res_ir in vect {
+                let element = emit_java(res_ir.clone(), trailer);
+                if !element.is_empty() {
+                    res = br!(res, format!(".extend({})", element));
+                }
+            }
+            res
+        }
+
+        ResourceIr::If(cond_id, val_true, val_false) => {
+            format!(
+                "Fn.conditionIf(\"{}\", {}, {})",
+                cond_id,
+                emit_java(*val_true, None),
+                emit_java(*val_false, None)
+            )
+        }
+        ResourceIr::Ref(reference) => emit_reference(reference),
+        ResourceIr::Join(delimiter, resources) => {
+            let mut res = format!("Fn.join(\"{delimiter}\", new GenericList<String>()");
+            for resource in resources {
+                let element = emit_java(resource, None);
+                if !element.is_empty() {
+                    res = br!(res, format!(".extend({})", element))
+                }
+            }
+            format!("{res})")
+        }
+        ResourceIr::Split(string, resource) => {
+            format!(
+                "Fn.split({}, String.valueOf({}))",
+                string,
+                emit_java(*resource, None)
+            )
+        }
+        ResourceIr::Base64(resource) => {
+            format!("Fn.base64(String.valueOf({}))", emit_java(*resource, None))
+        }
+        ResourceIr::GetAZs(resource) => {
+            format!("Fn.getAzs(String.valueOf({}))", emit_java(*resource, None))
+        }
+        ResourceIr::Sub(resources) => {
+            if let Some((first_elem, vect)) = resources.split_first() {
+                let body = emit_java(first_elem.clone(), None);
+                if vect.is_empty() {
+                    format!("Fn.sub(String.valueOf({}))", body);
+                }
+
+                let mut res = format!(
+                    "Fn.sub(String.valueOf({}), new GenericMap<String, String>()",
+                    body
+                );
+                for chunk in vect.chunks(2) {
+                    if let [key, value] = chunk {
+                        let key_element = emit_java(key.clone(), None);
+                        let value_element = emit_java(value.clone(), None);
+                        res = br!(res, format!(".extend({}, {})", key_element, value_element));
+                    }
+                }
+                return format!("{res})");
+            }
+            panic!("🚨 Fn::Sub improperly formatted")
+        }
+        ResourceIr::Map(resource, key, value) => {
+            format!(
+                "Fn.findInMap(\"{}\", {}, {})",
+                resource,
+                emit_java(*key, None),
+                emit_java(*value, None),
+            )
+        }
+        ResourceIr::Cidr(p0, p1, p2) => {
+            format!(
+                "Fn.cidr(String.valueOf({}), {}, String.valueOf({}))",
+                emit_java(*p0, None),
+                emit_java(*p1, None),
+                emit_java(*p2, None)
+            )
+        }
+        ResourceIr::Select(size, resource) => {
+            let used_type: String = match *resource.clone() {
+                ResourceIr::Array(structure, _) => match structure {
+                    Structure::Simple(cfn_type) => match_cfn_type(&cfn_type),
+                    _ => "".into(),
+                },
+                _ => "".into(),
+            };
+            if !used_type.is_empty() {
+                format!(
+                    "{}.valueOf(Fn.select({},get({})))",
+                    used_type,
+                    size,
+                    emit_java(*resource, None)
+                )
+            } else {
+                format!("Fn.select({},get({}))", size, emit_java(*resource, None))
+            }
+        }
+    }
+}
+
+fn name(key: &String) -> String {
+    camel_case(&key)
+        .chars()
+        .filter(|c| c.is_alphanumeric())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {}

--- a/src/synthesizer/mod.rs
+++ b/src/synthesizer/mod.rs
@@ -21,12 +21,22 @@ mod typescript;
 pub use typescript::*;
 
 pub trait Synthesizer {
-    fn synthesize(&self, ir: CloudformationProgramIr, into: &mut dyn io::Write) -> io::Result<()>;
+    fn synthesize(
+        &self,
+        ir: CloudformationProgramIr,
+        into: &mut dyn io::Write,
+        stack_name: &str,
+    ) -> io::Result<()>;
 }
 
 impl CloudformationProgramIr {
     #[inline(always)]
-    pub fn synthesize(self, using: &dyn Synthesizer, into: &mut impl io::Write) -> io::Result<()> {
-        using.synthesize(self, into)
+    pub fn synthesize(
+        self,
+        using: &dyn Synthesizer,
+        into: &mut impl io::Write,
+        stack_name: &str,
+    ) -> io::Result<()> {
+        using.synthesize(self, into, stack_name)
     }
 }

--- a/src/synthesizer/mod.rs
+++ b/src/synthesizer/mod.rs
@@ -8,6 +8,12 @@ mod golang;
 #[doc(inline)]
 pub use golang::*;
 
+#[cfg(feature = "java")]
+mod java;
+#[cfg(feature = "java")]
+#[doc(inline)]
+pub use java::*;
+
 #[cfg(feature = "typescript")]
 mod typescript;
 #[cfg(feature = "typescript")]

--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -439,6 +439,7 @@ fn emit_resource_props<S>(
         output.text(format!("{}: ", prop_name));
         let keep_prop_name = 
             prop_name.to_lowercase() == "assumerolepolicydocument" || 
+            prop_name.to_lowercase() == "policies" || 
             prop_name.to_lowercase() == "policydocument";
         emit_resource_ir(context, &output, prop, Some(",\n"), keep_prop_name);
     }

--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -26,7 +26,9 @@ impl Typescript {
     #[deprecated(note = "Prefer using the Synthesizer API instead")]
     pub fn output(ir: CloudformationProgramIr) -> String {
         let mut output = Vec::new();
-        Typescript {}.synthesize(ir, &mut output).unwrap();
+        Typescript {}
+            .synthesize(ir, &mut output, "NoctStack")
+            .unwrap();
         String::from_utf8(output).unwrap()
     }
 }
@@ -36,6 +38,7 @@ impl Synthesizer for Typescript {
         &self,
         ir: CloudformationProgramIr,
         output: &mut dyn io::Write,
+        stack_name: &str,
     ) -> io::Result<()> {
         let code = CodeBuffer::default();
 
@@ -52,7 +55,13 @@ impl Synthesizer for Typescript {
 
         let iface_props = code.indent_with_options(IndentOptions {
             indent: INDENT,
-            leading: Some("export interface NoctStackProps extends cdk.StackProps {".into()),
+            leading: Some(
+                format!(
+                    "export interface {}Props extends cdk.StackProps {{",
+                    stack_name
+                )
+                .into(),
+            ),
             trailing: Some("}".into()),
             trailing_newline: true,
         });
@@ -92,7 +101,7 @@ impl Synthesizer for Typescript {
         }
         let class = code.indent_with_options(IndentOptions {
             indent: INDENT,
-            leading: Some("export class NoctStack extends cdk.Stack {".into()),
+            leading: Some(format!("export class {} extends cdk.Stack {{", stack_name).into()),
             trailing: Some("}".into()),
             trailing_newline: true,
         });
@@ -128,7 +137,7 @@ impl Synthesizer for Typescript {
 
         let  ctor = class.indent_with_options(IndentOptions{
             indent: INDENT,
-            leading: Some(format!("public constructor(scope: cdk.App, id: string, props: NoctStackProps{default_empty}) {{").into()),
+            leading: Some(format!("public constructor(scope: cdk.App, id: string, props: {}Props{default_empty}) {{", stack_name).into()),
             trailing: Some("}".into()),
             trailing_newline: true,
         });

--- a/tests/end-to-end.rs
+++ b/tests/end-to-end.rs
@@ -3,27 +3,34 @@ use noctilucent::synthesizer::*;
 use noctilucent::CloudformationParseTree;
 
 macro_rules! test_case {
-    ($name:ident) => {
+    ($name:ident, $stack_name:literal) => {
         mod $name {
             use super::*;
 
             #[cfg(feature = "golang")]
-            test_case!($name, golang, &Golang::new(stringify!($name)), "app.go");
+            test_case!(
+                $name,
+                golang,
+                &Golang::new(stringify!($name)),
+                $stack_name,
+                "app.go"
+            );
 
             #[cfg(feature = "java")]
             test_case!(
                 $name,
                 java,
                 &Java::new(concat!("com.acme.test.", stringify!($name))),
+                $stack_name,
                 "App.java"
             );
 
             #[cfg(feature = "typescript")]
-            test_case!($name, typescript, &Typescript {}, "app.ts");
+            test_case!($name, typescript, &Typescript {}, $stack_name, "app.ts");
         }
     };
 
-    ($name:ident, $lang:ident, $synthesizer:expr, $expected:literal) => {
+    ($name:ident, $lang:ident, $synthesizer:expr, $stack_name:literal, $expected:literal) => {
         #[test]
         fn $lang() {
             let expected = include_str!(concat!("end-to-end/", stringify!($name), "/", $expected));
@@ -36,7 +43,8 @@ macro_rules! test_case {
                 )))
                 .unwrap();
                 let ir = CloudformationProgramIr::from(cfn).unwrap();
-                ir.synthesize($synthesizer, &mut output).unwrap();
+                ir.synthesize($synthesizer, &mut output, $stack_name)
+                    .unwrap();
                 String::from_utf8(output).unwrap()
             };
 
@@ -50,9 +58,11 @@ macro_rules! test_case {
     };
 }
 
-test_case!(simple);
-test_case!(vpc);
-test_case!(role);
+test_case!(simple, "SimpleStack");
+
+test_case!(vpc, "VpcStack");
+
+test_case!(role, "RoleStack");
 
 struct UpdateSnapshot<'a> {
     path: &'static str,

--- a/tests/end-to-end.rs
+++ b/tests/end-to-end.rs
@@ -68,6 +68,7 @@ macro_rules! test_case {
 
 test_case!(simple);
 test_case!(vpc);
+test_case!(role);
 
 struct UpdateSnapshot<'a> {
     path: &'static str,

--- a/tests/end-to-end/role/app.go
+++ b/tests/end-to-end/role/app.go
@@ -1,0 +1,54 @@
+package role
+
+import (
+	"fmt"
+
+	cdk "github.com/aws/aws-cdk-go/awscdk/v2"
+	iam "github.com/aws/aws-cdk-go/awscdk/v2/awsiam"
+	"github.com/aws/constructs-go/constructs/v10"
+	"github.com/aws/jsii-runtime-go"
+)
+
+type NoctStackProps struct {
+	cdk.StackProps
+}
+
+type NoctStack struct {
+	cdk.Stack
+}
+
+func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *NoctStack {
+	stack := cdk.NewStack(scope, &id, &props.StackProps)
+
+	iam.NewCfnRole(
+		stack,
+		jsii.String("MyRole"),
+		&iam.CfnRoleProps{
+			AssumeRolePolicyDocument: interface{}{
+				Statement: &[]interface{}{
+					interface{}{
+						Action: &[]interface{}{
+							jsii.String("sts:AssumeRole"),
+						},
+						Condition: interface{}{
+							StringLike: interface{}{
+								Kms:ViaService: jsii.String(fmt.Sprintf("s3.us-east-1.amazonaws.com")),
+							},
+						},
+						Effect: jsii.String("Allow"),
+						Principal: interface{}{
+							Service: &[]interface{}{
+								jsii.String("lambda.amazonaws.com"),
+							},
+						},
+					},
+				},
+				Version: jsii.String("2012-10-17"),
+			},
+		},
+	)
+
+	return &NoctStack{
+		Stack: stack,
+	}
+}

--- a/tests/end-to-end/role/app.ts
+++ b/tests/end-to-end/role/app.ts
@@ -1,0 +1,36 @@
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+
+export interface NoctStackProps extends cdk.StackProps {
+}
+
+export class NoctStack extends cdk.Stack {
+  public constructor(scope: cdk.App, id: string, props: NoctStackProps = {}) {
+    super(scope, id, props);
+
+    // Resources
+    const myRole = new iam.CfnRole(this, 'MyRole', {
+      assumeRolePolicyDocument: {
+        'Statement': [
+          {
+            'Action': [
+              'sts:AssumeRole',
+            ],
+            'Condition': {
+              'StringLike': {
+                'kms:ViaService': `s3.us-east-1.amazonaws.com`,
+              },
+            },
+            'Effect': 'Allow',
+            'Principal': {
+              'Service': [
+                'lambda.amazonaws.com',
+              ],
+            },
+          },
+        ],
+        'Version': '2012-10-17',
+      },
+    });
+  }
+}

--- a/tests/end-to-end/role/template.yml
+++ b/tests/end-to-end/role/template.yml
@@ -1,0 +1,17 @@
+Resources:
+  MyRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - 'sts:AssumeRole'
+            Condition:
+              StringLike:
+                'kms:ViaService':
+                  'Fn::Sub': 's3.us-east-1.amazonaws.com'
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+        Version: '2012-10-17'

--- a/tests/end-to-end/simple/App.java
+++ b/tests/end-to-end/simple/App.java
@@ -1,0 +1,190 @@
+package com.acme.test.simple;
+
+import software.constructs.Construct;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import software.amazon.awscdk.*;
+import software.amazon.awscdk.App;
+import software.amazon.awscdk.CfnMapping;
+import software.amazon.awscdk.CfnTag;
+import software.amazon.awscdk.Stack;
+import software.amazon.awscdk.StackProps;
+
+import software.amazon.awscdk.services.s3.*;
+import software.amazon.awscdk.services.sqs.*;
+
+public class NoctApp {
+  public static void main(final String[] args) {
+    App app = new App();
+    StackProps props = StackProps.builder()
+      .description("An example stack that uses many of the syntax elements permitted in a" + 
+        "CloudFormation template, but does not attempt to represent a realistic stack.")
+      .build();
+    new NoctStack(app, "MyProjectStack", props);
+    app.synth();
+  }
+}
+
+interface NoctStackProps extends StackProps {
+}
+
+class NoctStack extends Stack {
+  private CfnOutput bucketArn, queueArn, isLarge;
+
+  public CfnOutput getBucketArn() {
+    return this.bucketArn;
+  }
+  public CfnOutput getQueueArn() {
+    return this.queueArn;
+  }
+  public CfnOutput getIsLarge() {
+    return this.isLarge;
+  }
+  public NoctStack(final Construct scope, final String id) {
+    super(scope, id, null);
+  }
+  public NoctStack(final Construct scope, final String id, final StackProps props) {
+    super(scope, id, props);
+    // Start Mapping section
+    final Mapping<Boolean> booleans = new Mapping<>(this, "Booleans");
+    booleans.put("True", "true", true);
+    booleans.put("False", "false", false);
+    final CfnMapping booleansCfnMapping = booleans.get();
+
+    final Mapping<List<String>> lists = new Mapping<>(this, "Lists");
+    lists.put("Candidates", "Empty", new GenericList<String>());
+    lists.put("Candidates", "Singleton", new GenericList<String>()
+        .extend("One"));
+    lists.put("Candidates", "Pair", new GenericList<String>()
+        .extend("One")
+        .extend("Two"));
+    final CfnMapping listsCfnMapping = lists.get();
+
+    final Mapping<Integer> numbers = new Mapping<>(this, "Numbers");
+    numbers.put("Prime", "Eleven", 11);
+    numbers.put("Prime", "Thirteen", 13);
+    numbers.put("Prime", "Seventeen", 17);
+    final CfnMapping numbersCfnMapping = numbers.get();
+
+    final Mapping<String> strings = new Mapping<>(this, "Strings");
+    strings.put("Foos", "Foo1", "Foo1");
+    strings.put("Foos", "Foo2", "Foo2");
+    strings.put("Bars", "Bar", "Bar");
+    final CfnMapping stringsCfnMapping = strings.get();
+
+    final Mapping<Object> table = new Mapping<>(this, "Table");
+    table.put("Values", "Boolean", true);
+    table.put("Values", "Float", 3.14);
+    table.put("Values", "List", new GenericList<String>()
+        .extend("1")
+        .extend("2")
+        .extend("3"));
+    table.put("Values", "Number", 42);
+    table.put("Values", "String", "Baz");
+    final CfnMapping tableCfnMapping = table.get();
+
+    CfnParameter bucketNamePrefix = CfnParameter.Builder.create(this, "bucketNamePrefix")
+      .description("The prefix for the bucket name")
+      .defaultValue(String.valueOf("bucket"))
+      .build();
+    CfnCondition isUs = CfnCondition.Builder.create(this, "IsUs").expression(Fn.conditionEquals(Fn.select(0, get(Fn.split("-", this.getRegion()))), "us")).build();
+    CfnCondition isUsEast1 = CfnCondition.Builder.create(this, "IsUsEast1").expression(Fn.conditionEquals(this.getRegion(), "us-east-1")).build();
+    CfnCondition isLargeRegion = CfnCondition.Builder.create(this, "IsLargeRegion").expression(isUsEast1).build();
+
+    CfnQueue queue = CfnQueue.Builder.create(this, "Queue")
+        .delaySeconds(42.1337)
+        .fifoQueue(false)
+        .kmsMasterKeyId("Shared.KmsKeyArn")
+        .queueName(Fn.join("-", new GenericList<String>()
+          .extend(this.getStackName())
+          .extend(Fn.findInMap("Strings", "Bars", "Bar"))
+          .extend(Fn.select(1,get(Fn.getAzs(String.valueOf(this.getRegion())))))))
+        .redrivePolicy(null)
+        .visibilityTimeout(Integer.valueOf(Fn.select(1,get(new GenericList<Integer>()
+          .extend(60)
+          .extend(120)
+          .extend(240)))))
+      .build();
+
+
+    CfnBucket bucket = CfnBucket.Builder.create(this, "Bucket")
+        .accessControl("private")
+        .bucketName(Fn.sub(String.valueOf(bucketNamePrefix), new GenericMap<String, String>()
+          .extend("-", this.getStackName())))
+        .tags(new GenericList<CfnTag>()
+          .extend(new GenericMap<String, Object>()
+          .extend("FancyTag",Fn.conditionIf("IsUsEast1", Fn.base64(String.valueOf(Fn.findInMap("Table", "Values", "String"))), Fn.base64(String.valueOf("8CiMvAo="))))
+          .getTags()))
+      .build();
+
+    bucketArn = CfnOutput.Builder.create(this, "BucketArn")
+      .value(String.valueOf(Fn.getAtt("Bucket", "Arn")))
+      .description("The ARN of the bucket in this template!")
+      .exportName("ExportName")
+      .condition(isUsEast1)  .build();
+    queueArn = CfnOutput.Builder.create(this, "QueueArn")
+      .value(String.valueOf("Queue"))
+      .description("The ARN of the SQS Queue")  .build();
+    isLarge = CfnOutput.Builder.create(this, "IsLarge")
+      .value(String.valueOf(Fn.conditionIf("IsLargeRegion", true, false)))
+      .description("Whether this is a large region or not")  .build();
+  }
+
+  public static <T> List<String> get(final List<T> input) {
+    return input.stream().map(String::valueOf).collect(Collectors.toList());
+  }
+}
+class GenericList<T> extends LinkedList<T> {
+  public GenericList<T> extend(final T object) {
+    this.addLast(object);
+    return this;
+  }
+
+  public GenericList<T> extend(final List<T> collection) {
+    this.addAll(collection);
+    return this;
+  }
+}
+
+class GenericMap<T, S> extends HashMap<T, S> {
+  public GenericMap<T, S> extend(final T key, final S value) {
+    this.put(key, value);
+    return this;
+  }
+
+  public List<CfnTag> getTags() {
+    final List<CfnTag> tags = new LinkedList<>();
+    for (Map.Entry<T, S> entry : this.entrySet()) {
+      tags.add(
+          CfnTag.builder()
+              .key(String.valueOf(entry.getKey()))
+              .value(String.valueOf(entry.getValue()))
+              .build());
+    }
+    return tags;
+  }
+}
+
+class Mapping<T> {
+  private final String name;
+  private final Construct scope;
+  private final Map<String, Map<String, T>> inner = new TreeMap<>();
+
+  public Mapping(Construct scope, String name) {
+    this.name = name;
+    this.scope = scope;
+  }
+
+  public Mapping<T> put(String primaryKey, String secondaryKey, T value) {
+    final Map<String, T> map = inner.getOrDefault(primaryKey, new TreeMap<>());
+    map.put(secondaryKey, value);
+    inner.put(primaryKey, map);
+    return this;
+  }
+
+  public CfnMapping get() {
+    return CfnMapping.Builder.create(this.scope, this.name).mapping(this.inner).build();
+  }
+}
+

--- a/tests/end-to-end/simple/App.java
+++ b/tests/end-to-end/simple/App.java
@@ -21,15 +21,15 @@ public class NoctApp {
       .description("An example stack that uses many of the syntax elements permitted in a" + 
         "CloudFormation template, but does not attempt to represent a realistic stack.")
       .build();
-    new NoctStack(app, "MyProjectStack", props);
+    new SimpleStack(app, "MyProjectStack", props);
     app.synth();
   }
 }
 
-interface NoctStackProps extends StackProps {
+interface SimpleStackProps extends StackProps {
 }
 
-class NoctStack extends Stack {
+class SimpleStack extends Stack {
   private CfnOutput bucketArn, queueArn, isLarge;
 
   public CfnOutput getBucketArn() {
@@ -41,10 +41,10 @@ class NoctStack extends Stack {
   public CfnOutput getIsLarge() {
     return this.isLarge;
   }
-  public NoctStack(final Construct scope, final String id) {
+  public SimpleStack(final Construct scope, final String id) {
     super(scope, id, null);
   }
-  public NoctStack(final Construct scope, final String id, final StackProps props) {
+  public SimpleStack(final Construct scope, final String id, final StackProps props) {
     super(scope, id, props);
     // Start Mapping section
     final Mapping<Boolean> booleans = new Mapping<>(this, "Booleans");

--- a/tests/end-to-end/simple/app.go
+++ b/tests/end-to-end/simple/app.go
@@ -136,8 +136,16 @@ func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *
 
 	cdk.NewCfnOutput(stack, jsii.String("BucketArn"), &cdk.CfnOutputProps{
 		Description: jsii.String("The ARN of the bucket in this template!"),
-		ExportName: jsii.String("ExportName"),
+		ExportName: interface{}{
+			Name: jsii.String("ExportName"),
+		},
 		Value: bucket.AttrArn(),
+	})
+
+	cdk.NewCfnOutput(stack, jsii.String("QueueArn"), &cdk.CfnOutputProps{
+		Description: jsii.String("The ARN of the SQS Queue"),
+		ExportName: jsii.String("ExportName2"),
+		Value: queue.Ref(),
 	})
 
 	return &NoctStack{

--- a/tests/end-to-end/simple/app.go
+++ b/tests/end-to-end/simple/app.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/jsii-runtime-go"
 )
 
-type NoctStackProps struct {
+type SimpleStackProps struct {
 	cdk.StackProps
 	/// The prefix for the bucket name
 	BucketNamePrefix *string
@@ -18,7 +18,7 @@ type NoctStackProps struct {
 
 /// An example stack that uses many of the syntax elements permitted in a
 /// CloudFormation template, but does not attempt to represent a realistic stack.
-type NoctStack struct {
+type SimpleStack struct {
 	cdk.Stack
 	/// The ARN of the bucket in this template!
 	BucketArn interface{} // TODO: fix to appropriate type
@@ -28,7 +28,7 @@ type NoctStack struct {
 	IsLarge interface{} // TODO: fix to appropriate type
 }
 
-func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *NoctStack {
+func NewSimpleStack(scope constructs.Construct, id string, props SimpleStackProps) *SimpleStack {
 	/*
 	booleans := map[*string]map[*string]*bool{
 		jsii.String("True"): map[*string]*bool{
@@ -148,7 +148,7 @@ func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *
 		Value: queue.Ref(),
 	})
 
-	return &NoctStack{
+	return &SimpleStack{
 		Stack: stack,
 		BucketArn: bucket.AttrArn(),
 		QueueArn: queue.Ref(),

--- a/tests/end-to-end/simple/app.ts
+++ b/tests/end-to-end/simple/app.ts
@@ -114,7 +114,7 @@ export class NoctStack extends cdk.Stack {
       : undefined;
     if (bucket != null) {
       bucket.cfnOptions.metadata = {
-        CostCenter: 1337,
+        'CostCenter': 1337,
       };
       bucket.cfnOptions.deletionPolicy = cdk.CfnDeletionPolicy.RETAIN;
       bucket.addDependency(queue);
@@ -128,10 +128,15 @@ export class NoctStack extends cdk.Stack {
       new cdk.CfnOutput(this, 'BucketArn', {
         description: 'The ARN of the bucket in this template!',
         exportName: 'ExportName',
-        value: this.bucketArn,
+        value: this.bucketArn!,
       });
     }
     this.queueArn = queue.ref;
+    new cdk.CfnOutput(this, 'QueueArn', {
+      description: 'The ARN of the SQS Queue',
+      exportName: 'ExportName2',
+      value: this.queueArn!,
+    });
     this.isLarge = isLargeRegion ? true : false;
   }
 }

--- a/tests/end-to-end/simple/app.ts
+++ b/tests/end-to-end/simple/app.ts
@@ -3,7 +3,7 @@ import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import { Buffer } from 'buffer';
 
-export interface NoctStackProps extends cdk.StackProps {
+export interface SimpleStackProps extends cdk.StackProps {
   /**
    * The prefix for the bucket name
    * @default "bucket"
@@ -15,7 +15,7 @@ export interface NoctStackProps extends cdk.StackProps {
  * An example stack that uses many of the syntax elements permitted in a
  * CloudFormation template, but does not attempt to represent a realistic stack.
  */
-export class NoctStack extends cdk.Stack {
+export class SimpleStack extends cdk.Stack {
   /**
    * The ARN of the bucket in this template!
    */
@@ -29,7 +29,7 @@ export class NoctStack extends cdk.Stack {
    */
   public readonly isLarge;
 
-  public constructor(scope: cdk.App, id: string, props: NoctStackProps = {}) {
+  public constructor(scope: cdk.App, id: string, props: SimpleStackProps = {}) {
     super(scope, id, props);
 
     // Applying default props

--- a/tests/end-to-end/simple/template.yml
+++ b/tests/end-to-end/simple/template.yml
@@ -98,12 +98,14 @@ Outputs:
   BucketArn:
     Condition: IsUsEast1
     Description: The ARN of the bucket in this template!
-    Export: ExportName
+    Export: 
+      Name: ExportName
     Value:
       !GetAtt Bucket.Arn
 
   QueueArn:
     Description: The ARN of the SQS Queue
+    Export: ExportName2
     Value: !Ref Queue
 
   IsLarge:

--- a/tests/end-to-end/simple/template.yml
+++ b/tests/end-to-end/simple/template.yml
@@ -42,7 +42,7 @@ Conditions:
   IsUs:
     Fn::Equals:
       - Fn::Select:
-        - 0
+        - "0"
         - Fn::Split:
           - "-"
           - "!Ref": AWS::Region
@@ -89,7 +89,7 @@ Resources:
       RedrivePolicy: !Ref AWS::NoValue
       VisibilityTimeout:
         Fn::Select:
-          - 1
+          - "1"
           - - 60
             - 120
             - 240

--- a/tests/end-to-end/vpc/App.java
+++ b/tests/end-to-end/vpc/App.java
@@ -19,19 +19,19 @@ public class NoctApp {
     StackProps props = StackProps.builder()
       ""
       .build();
-    new NoctStack(app, "MyProjectStack", props);
+    new VpcStack(app, "MyProjectStack", props);
     app.synth();
   }
 }
 
-interface NoctStackProps extends StackProps {
+interface VpcStackProps extends StackProps {
 }
 
-class NoctStack extends Stack {
-  public NoctStack(final Construct scope, final String id) {
+class VpcStack extends Stack {
+  public VpcStack(final Construct scope, final String id) {
     super(scope, id, null);
   }
-  public NoctStack(final Construct scope, final String id, final StackProps props) {
+  public VpcStack(final Construct scope, final String id, final StackProps props) {
     super(scope, id, props);
     // Start Mapping section
 

--- a/tests/end-to-end/vpc/App.java
+++ b/tests/end-to-end/vpc/App.java
@@ -1,0 +1,127 @@
+package com.acme.test.vpc;
+
+import software.constructs.Construct;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import software.amazon.awscdk.*;
+import software.amazon.awscdk.App;
+import software.amazon.awscdk.CfnMapping;
+import software.amazon.awscdk.CfnTag;
+import software.amazon.awscdk.Stack;
+import software.amazon.awscdk.StackProps;
+
+import software.amazon.awscdk.services.ec2.*;
+
+public class NoctApp {
+  public static void main(final String[] args) {
+    App app = new App();
+    StackProps props = StackProps.builder()
+      ""
+      .build();
+    new NoctStack(app, "MyProjectStack", props);
+    app.synth();
+  }
+}
+
+interface NoctStackProps extends StackProps {
+}
+
+class NoctStack extends Stack {
+  public NoctStack(final Construct scope, final String id) {
+    super(scope, id, null);
+  }
+  public NoctStack(final Construct scope, final String id, final StackProps props) {
+    super(scope, id, props);
+    // Start Mapping section
+
+    CfnVPC vpc = CfnVPC.Builder.create(this, "VPC")
+        .cidrBlock("10.42.0.0/16")
+        .enableDnsSupport(true)
+        .enableDnsHostnames(true)
+        .tags(new GenericList<CfnTag>()
+          .extend(new GenericMap<String, Object>()
+          .extend("cost-center",1337)
+          .getTags()))
+      .build();
+
+
+    CfnSubnet subnet1 = CfnSubnet.Builder.create(this, "Subnet1")
+        .availabilityZone(Fn.select(0,get(Fn.getAzs(String.valueOf(/* validate FIXME */ "")))))
+        .cidrBlock(Fn.select(0,get(Fn.cidr(String.valueOf(Fn.getAtt("VPC", "CidrBlock")), 6, String.valueOf(8)))))
+        .vpcId("VPC")
+      .build();
+
+
+    CfnSubnet subnet2 = CfnSubnet.Builder.create(this, "Subnet2")
+        .availabilityZone(Fn.select(1,get(Fn.getAzs(String.valueOf(/* validate FIXME */ "")))))
+        .cidrBlock(Fn.select(1,get(Fn.cidr(String.valueOf(Fn.getAtt("VPC", "CidrBlock")), 6, String.valueOf(8)))))
+        .vpcId("VPC")
+      .build();
+
+
+    CfnSubnet subnet3 = CfnSubnet.Builder.create(this, "Subnet3")
+        .availabilityZone(Fn.select(2,get(Fn.getAzs(String.valueOf(/* validate FIXME */ "")))))
+        .cidrBlock(Fn.select(2,get(Fn.cidr(String.valueOf(Fn.getAtt("VPC", "CidrBlock")), 6, String.valueOf(8)))))
+        .vpcId("VPC")
+      .build();
+
+  }
+
+  public static <T> List<String> get(final List<T> input) {
+    return input.stream().map(String::valueOf).collect(Collectors.toList());
+  }
+}
+class GenericList<T> extends LinkedList<T> {
+  public GenericList<T> extend(final T object) {
+    this.addLast(object);
+    return this;
+  }
+
+  public GenericList<T> extend(final List<T> collection) {
+    this.addAll(collection);
+    return this;
+  }
+}
+
+class GenericMap<T, S> extends HashMap<T, S> {
+  public GenericMap<T, S> extend(final T key, final S value) {
+    this.put(key, value);
+    return this;
+  }
+
+  public List<CfnTag> getTags() {
+    final List<CfnTag> tags = new LinkedList<>();
+    for (Map.Entry<T, S> entry : this.entrySet()) {
+      tags.add(
+          CfnTag.builder()
+              .key(String.valueOf(entry.getKey()))
+              .value(String.valueOf(entry.getValue()))
+              .build());
+    }
+    return tags;
+  }
+}
+
+class Mapping<T> {
+  private final String name;
+  private final Construct scope;
+  private final Map<String, Map<String, T>> inner = new TreeMap<>();
+
+  public Mapping(Construct scope, String name) {
+    this.name = name;
+    this.scope = scope;
+  }
+
+  public Mapping<T> put(String primaryKey, String secondaryKey, T value) {
+    final Map<String, T> map = inner.getOrDefault(primaryKey, new TreeMap<>());
+    map.put(secondaryKey, value);
+    inner.put(primaryKey, map);
+    return this;
+  }
+
+  public CfnMapping get() {
+    return CfnMapping.Builder.create(this.scope, this.name).mapping(this.inner).build();
+  }
+}
+

--- a/tests/end-to-end/vpc/app.go
+++ b/tests/end-to-end/vpc/app.go
@@ -7,15 +7,15 @@ import (
 	"github.com/aws/jsii-runtime-go"
 )
 
-type NoctStackProps struct {
+type VpcStackProps struct {
 	cdk.StackProps
 }
 
-type NoctStack struct {
+type VpcStack struct {
 	cdk.Stack
 }
 
-func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *NoctStack {
+func NewVpcStack(scope constructs.Construct, id string, props VpcStackProps) *VpcStack {
 	stack := cdk.NewStack(scope, &id, &props.StackProps)
 
 	vpc := ec2.NewCfnVPC(
@@ -64,7 +64,7 @@ func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *
 		},
 	)
 
-	return &NoctStack{
+	return &VpcStack{
 		Stack: stack,
 	}
 }

--- a/tests/end-to-end/vpc/app.ts
+++ b/tests/end-to-end/vpc/app.ts
@@ -1,11 +1,11 @@
 import * as cdk from 'aws-cdk-lib';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 
-export interface NoctStackProps extends cdk.StackProps {
+export interface VpcStackProps extends cdk.StackProps {
 }
 
-export class NoctStack extends cdk.Stack {
-  public constructor(scope: cdk.App, id: string, props: NoctStackProps = {}) {
+export class VpcStack extends cdk.Stack {
+  public constructor(scope: cdk.App, id: string, props: VpcStackProps = {}) {
     super(scope, id, props);
 
     // Resources


### PR DESCRIPTION
### Prop names containing special characters in policy documents and resource metadata
* Example cdk diff output
```
kms:EncryptionContext:aws:s3Arn: [
  ...
]
```
* Solution: Wrap the property name with quotes ('')* 

### Prop name case differences in policy documents and resource metadata
* Example cdk diff output
```
[~] AWS::IAM::Role CustomResourceDeadLetterLambdaRole CustomResourceDeadLetterLambdaRole
 ├─ [~] AssumeRolePolicyDocument
  │       ├─ [-] Removed: .Statement
  │       ├─ [-] Removed: .Version
  │       ├─ [+] Added: .statement
  │       └─ [+] Added: .version
```
* Solution: Keep the property names for `policyDocument` and `assumerolepolicydocument`

### CfnOutput's ExportName with Object
* Example code
```
      new cdk.CfnOutput(this, 'MyOutput', {
        exportName: {
          name: 'MyOutput',
        },
        ...
      }
```
* Solution: Unwrap the name value from the object 
```
      new cdk.CfnOutput(this, 'MyOutput', {
        exportName: 'MyOutput',
        ...
      }
```

### CfnOutput's Value with string|undefined type
```
      new cdk.CfnOutput(this, 'MyOutput', {
        value: this.a2zDnsHostZone,
        ...
      }
```
* Solution: Add ! at the end
```
      new cdk.CfnOutput(this, 'MyOutput', {
        value: this.a2zDnsHostZone!,
        ...
      }
```