### PR TITLE
fix(all): properly transform depends_on, and selection

### DIFF
--- a/tests/end-to-end/simple/template.yml
+++ b/tests/end-to-end/simple/template.yml
@@ -42,7 +42,7 @@ Conditions:
   IsUs:
     Fn::Equals:
       - Fn::Select:
-        - 0
+        - "0"
         - Fn::Split:
           - "-"
           - "!Ref": AWS::Region
@@ -89,7 +89,7 @@ Resources:
       RedrivePolicy: !Ref AWS::NoValue
       VisibilityTimeout:
         Fn::Select:
-          - 1
+          - "1"
           - - 60
             - 120
             - 240


### PR DESCRIPTION
With the move to proper typing in parsing, we accidentally shed some valuable transforms that CloudFormation takes on behalf of the customer. This brings back those transforms.

Specifically:
- DependsOn is allowed to have a single value
- Select index can be a string that is parse-able into an int