### PR TITLE
feat: enable users to define stack name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub mod wasm {
     /// Transforms the provided template into a CDK application in the specified
     /// language.
     #[wasm_bindgen]
-    pub fn transmute(template: &str, language: &str) -> Result<String, JsError> {
+    pub fn transmute(template: &str, language: &str, stack_name: &str) -> Result<String, JsError> {
         let cfn_tree: CloudformationParseTree = serde_yaml::from_str(template)?;
         let ir = crate::ir::CloudformationProgramIr::from(cfn_tree)?;
         let mut output = Vec::new();
@@ -73,7 +73,7 @@ pub mod wasm {
             unsupported => panic!("unsupported language: {}", unsupported),
         };
 
-        ir.synthesize(synthesizer.as_ref(), &mut output)?;
+        ir.synthesize(synthesizer.as_ref(), &mut output, stack_name)?;
 
         String::from_utf8(output).map_err(Into::into)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,13 +91,10 @@ fn main() -> anyhow::Result<()> {
         unsupported => panic!("unsupported language: {}", unsupported),
     };
 
-    let stack_name: &str = match matches
+    let stack_name = matches
         .get_one::<String>("stack-name")
         .map(String::as_str)
-        .unwrap_or("NoctStack") 
-    {
-        stack_name => stack_name,
-    };
+        .unwrap_or("NoctStack");
 
     ir.synthesize(synthesizer.as_ref(), &mut output, stack_name)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,14 @@ fn main() -> anyhow::Result<()> {
                 .value_parser(targets)
                 .action(ArgAction::Set),
         )
+        .arg(
+            Arg::new("stack-name")
+                .help("Sets the name of the stack")
+                .required(false)
+                .long("stack-name")
+                .short('s')
+                .action(ArgAction::Set),
+        )
         .get_matches();
 
     let cfn_tree: CloudformationParseTree = {
@@ -83,7 +91,15 @@ fn main() -> anyhow::Result<()> {
         unsupported => panic!("unsupported language: {}", unsupported),
     };
 
-    ir.synthesize(synthesizer.as_ref(), &mut output)?;
+    let stack_name: &str = match matches
+        .get_one::<String>("stack-name")
+        .map(String::as_str)
+        .unwrap_or("NoctStack") 
+    {
+        stack_name => stack_name,
+    };
+
+    ir.synthesize(synthesizer.as_ref(), &mut output, stack_name)?;
 
     Ok(())
 }

--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -39,7 +39,7 @@ impl Default for Golang {
 }
 
 impl Synthesizer for Golang {
-    fn synthesize(&self, ir: CloudformationProgramIr, into: &mut dyn io::Write) -> io::Result<()> {
+    fn synthesize(&self, ir: CloudformationProgramIr, into: &mut dyn io::Write, stack_name: &str) -> io::Result<()> {
         let code = CodeBuffer::default();
 
         code.line(format!("package {}", self.package_name));
@@ -64,7 +64,7 @@ impl Synthesizer for Golang {
 
         let props = code.indent_with_options(IndentOptions {
             indent: INDENT,
-            leading: Some("type NoctStackProps struct {".into()),
+            leading: Some(format!("type {}Props struct {{", stack_name).into()),
             trailing: Some("}".into()),
             trailing_newline: true,
         });
@@ -82,7 +82,7 @@ impl Synthesizer for Golang {
         }
         let class = code.indent_with_options(IndentOptions {
             indent: INDENT,
-            leading: Some("type NoctStack struct {".into()),
+            leading: Some(format!("type {} struct {{", stack_name).into()),
             trailing: Some("}".into()),
             trailing_newline: true,
         });
@@ -100,7 +100,7 @@ impl Synthesizer for Golang {
 
         let ctor = code.indent_with_options(IndentOptions{
             indent: INDENT,
-            leading: Some("func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *NoctStack {".into()),
+            leading: Some(format!("func New{}(scope constructs.Construct, id string, props {}Props) *{} {{", stack_name, stack_name, stack_name).into()),
             trailing: Some("}".into()),
             trailing_newline: true,
         });
@@ -270,7 +270,7 @@ impl Synthesizer for Golang {
 
         let fields = ctor.indent_with_options(IndentOptions {
             indent: INDENT,
-            leading: Some("return &NoctStack{".into()),
+            leading: Some(format!("return &{}{{", stack_name).into()),
             trailing: Some("}".into()),
             trailing_newline: true,
         });

--- a/src/synthesizer/golang/mod.rs
+++ b/src/synthesizer/golang/mod.rs
@@ -39,7 +39,12 @@ impl Default for Golang {
 }
 
 impl Synthesizer for Golang {
-    fn synthesize(&self, ir: CloudformationProgramIr, into: &mut dyn io::Write, stack_name: &str) -> io::Result<()> {
+    fn synthesize(
+        &self,
+        ir: CloudformationProgramIr,
+        into: &mut dyn io::Write,
+        stack_name: &str,
+    ) -> io::Result<()> {
         let code = CodeBuffer::default();
 
         code.line(format!("package {}", self.package_name));
@@ -98,9 +103,15 @@ impl Synthesizer for Golang {
         }
         code.newline();
 
-        let ctor = code.indent_with_options(IndentOptions{
+        let ctor = code.indent_with_options(IndentOptions {
             indent: INDENT,
-            leading: Some(format!("func New{}(scope constructs.Construct, id string, props {}Props) *{} {{", stack_name, stack_name, stack_name).into()),
+            leading: Some(
+                format!(
+                    "func New{}(scope constructs.Construct, id string, props {}Props) *{} {{",
+                    stack_name, stack_name, stack_name
+                )
+                .into(),
+            ),
             trailing: Some("}".into()),
             trailing_newline: true,
         });

--- a/src/synthesizer/java/mod.rs
+++ b/src/synthesizer/java/mod.rs
@@ -359,7 +359,12 @@ impl Default for Java {
 }
 
 impl Synthesizer for Java {
-    fn synthesize(&self, ir: CloudformationProgramIr, into: &mut dyn io::Write, stack_name: &str) -> io::Result<()> {
+    fn synthesize(
+        &self,
+        ir: CloudformationProgramIr,
+        into: &mut dyn io::Write,
+        stack_name: &str,
+    ) -> io::Result<()> {
         let code = CodeBuffer::default();
 
         self.write_header(&code);

--- a/src/synthesizer/java/mod.rs
+++ b/src/synthesizer/java/mod.rs
@@ -15,7 +15,6 @@ use std::rc::Rc;
 use voca_rs::case::{camel_case, pascal_case};
 
 const INDENT: Cow<'static, str> = Cow::Borrowed("  ");
-const STACK_NAME: Cow<'static, str> = Cow::Borrowed("NoctStack");
 
 macro_rules! fill {
     ($code:ident; $leading:expr; $($lines:expr),* ; $trailing:expr) => {
@@ -67,7 +66,7 @@ impl Java {
         code.line("import software.amazon.awscdk.StackProps;");
     }
 
-    fn write_app(&self, writer: &CodeBuffer, description: &Option<String>) {
+    fn write_app(&self, writer: &CodeBuffer, description: &Option<String>, stack_name: &str) {
         let app_name = "NoctApp";
         let class = &writer.indent_with_options(IndentOptions {
             indent: INDENT,
@@ -97,7 +96,7 @@ impl Java {
         };
         main.line(format!(
             "new {}(app, \"MyProjectStack\", props);",
-            STACK_NAME
+            stack_name
         ));
         main.line("app.synth();");
     }
@@ -360,7 +359,7 @@ impl Default for Java {
 }
 
 impl Synthesizer for Java {
-    fn synthesize(&self, ir: CloudformationProgramIr, into: &mut dyn io::Write) -> io::Result<()> {
+    fn synthesize(&self, ir: CloudformationProgramIr, into: &mut dyn io::Write, stack_name: &str) -> io::Result<()> {
         let code = CodeBuffer::default();
 
         self.write_header(&code);
@@ -370,13 +369,13 @@ impl Synthesizer for Java {
         }
         code.newline();
 
-        self.write_app(&code, &ir.description);
+        self.write_app(&code, &ir.description, stack_name);
 
-        fill!(code; format!("\ninterface {}Props extends StackProps {{", STACK_NAME);; "}" );
+        fill!(code; format!("\ninterface {}Props extends StackProps {{", stack_name);; "}" );
 
         let class = code.indent_with_options(IndentOptions {
             indent: INDENT,
-            leading: Some(format!("\nclass {} extends Stack {{", STACK_NAME).into()),
+            leading: Some(format!("\nclass {} extends Stack {{", stack_name).into()),
             trailing: Some("}".into()),
             trailing_newline: true,
         });
@@ -385,7 +384,7 @@ impl Synthesizer for Java {
         Self::write_field_logic(&class, output_names);
 
         fill!(class;
-            format!("public {}(final Construct scope, final String id) {{", STACK_NAME);
+            format!("public {}(final Construct scope, final String id) {{", stack_name);
             "super(scope, id, null);";
             "}" );
 
@@ -394,7 +393,7 @@ impl Synthesizer for Java {
             leading: Some(
                 format!(
                     "public {}(final Construct scope, final String id, final StackProps props) {{",
-                    STACK_NAME
+                    stack_name
                 )
                 .into(),
             ),

--- a/src/synthesizer/mod.rs
+++ b/src/synthesizer/mod.rs
@@ -21,12 +21,22 @@ mod typescript;
 pub use typescript::*;
 
 pub trait Synthesizer {
-    fn synthesize(&self, ir: CloudformationProgramIr, into: &mut dyn io::Write, stack_name: &str) -> io::Result<()>;
+    fn synthesize(
+        &self,
+        ir: CloudformationProgramIr,
+        into: &mut dyn io::Write,
+        stack_name: &str,
+    ) -> io::Result<()>;
 }
 
 impl CloudformationProgramIr {
     #[inline(always)]
-    pub fn synthesize(self, using: &dyn Synthesizer, into: &mut impl io::Write, stack_name: &str) -> io::Result<()> {
+    pub fn synthesize(
+        self,
+        using: &dyn Synthesizer,
+        into: &mut impl io::Write,
+        stack_name: &str,
+    ) -> io::Result<()> {
         using.synthesize(self, into, stack_name)
     }
 }

--- a/src/synthesizer/mod.rs
+++ b/src/synthesizer/mod.rs
@@ -21,12 +21,12 @@ mod typescript;
 pub use typescript::*;
 
 pub trait Synthesizer {
-    fn synthesize(&self, ir: CloudformationProgramIr, into: &mut dyn io::Write) -> io::Result<()>;
+    fn synthesize(&self, ir: CloudformationProgramIr, into: &mut dyn io::Write, stack_name: &str) -> io::Result<()>;
 }
 
 impl CloudformationProgramIr {
     #[inline(always)]
-    pub fn synthesize(self, using: &dyn Synthesizer, into: &mut impl io::Write) -> io::Result<()> {
-        using.synthesize(self, into)
+    pub fn synthesize(self, using: &dyn Synthesizer, into: &mut impl io::Write, stack_name: &str) -> io::Result<()> {
+        using.synthesize(self, into, stack_name)
     }
 }

--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -26,7 +26,7 @@ impl Typescript {
     #[deprecated(note = "Prefer using the Synthesizer API instead")]
     pub fn output(ir: CloudformationProgramIr) -> String {
         let mut output = Vec::new();
-        Typescript {}.synthesize(ir, &mut output).unwrap();
+        Typescript {}.synthesize(ir, &mut output, "NoctStack").unwrap();
         String::from_utf8(output).unwrap()
     }
 }
@@ -36,6 +36,7 @@ impl Synthesizer for Typescript {
         &self,
         ir: CloudformationProgramIr,
         output: &mut dyn io::Write,
+        stack_name: &str,
     ) -> io::Result<()> {
         let code = CodeBuffer::default();
 
@@ -52,7 +53,7 @@ impl Synthesizer for Typescript {
 
         let iface_props = code.indent_with_options(IndentOptions {
             indent: INDENT,
-            leading: Some("export interface NoctStackProps extends cdk.StackProps {".into()),
+            leading: Some(format!("export interface {}Props extends cdk.StackProps {{", stack_name).into()),
             trailing: Some("}".into()),
             trailing_newline: true,
         });
@@ -92,7 +93,7 @@ impl Synthesizer for Typescript {
         }
         let class = code.indent_with_options(IndentOptions {
             indent: INDENT,
-            leading: Some("export class NoctStack extends cdk.Stack {".into()),
+            leading: Some(format!("export class {} extends cdk.Stack {{", stack_name).into()),
             trailing: Some("}".into()),
             trailing_newline: true,
         });
@@ -128,7 +129,7 @@ impl Synthesizer for Typescript {
 
         let  ctor = class.indent_with_options(IndentOptions{
             indent: INDENT,
-            leading: Some(format!("public constructor(scope: cdk.App, id: string, props: NoctStackProps{default_empty}) {{").into()),
+            leading: Some(format!("public constructor(scope: cdk.App, id: string, props: {}Props{default_empty}) {{", stack_name).into()),
             trailing: Some("}".into()),
             trailing_newline: true,
         });

--- a/src/synthesizer/typescript/mod.rs
+++ b/src/synthesizer/typescript/mod.rs
@@ -26,7 +26,9 @@ impl Typescript {
     #[deprecated(note = "Prefer using the Synthesizer API instead")]
     pub fn output(ir: CloudformationProgramIr) -> String {
         let mut output = Vec::new();
-        Typescript {}.synthesize(ir, &mut output, "NoctStack").unwrap();
+        Typescript {}
+            .synthesize(ir, &mut output, "NoctStack")
+            .unwrap();
         String::from_utf8(output).unwrap()
     }
 }
@@ -53,7 +55,13 @@ impl Synthesizer for Typescript {
 
         let iface_props = code.indent_with_options(IndentOptions {
             indent: INDENT,
-            leading: Some(format!("export interface {}Props extends cdk.StackProps {{", stack_name).into()),
+            leading: Some(
+                format!(
+                    "export interface {}Props extends cdk.StackProps {{",
+                    stack_name
+                )
+                .into(),
+            ),
             trailing: Some("}".into()),
             trailing_newline: true,
         });

--- a/tests/end-to-end.rs
+++ b/tests/end-to-end.rs
@@ -3,27 +3,28 @@ use noctilucent::synthesizer::*;
 use noctilucent::CloudformationParseTree;
 
 macro_rules! test_case {
-    ($name:ident) => {
+    ($name:ident, $stack_name:literal) => {
         mod $name {
             use super::*;
 
             #[cfg(feature = "golang")]
-            test_case!($name, golang, &Golang::new(stringify!($name)), "app.go");
+            test_case!($name, golang, &Golang::new(stringify!($name)), $stack_name, "app.go");
 
             #[cfg(feature = "java")]
             test_case!(
                 $name,
                 java,
                 &Java::new(concat!("com.acme.test.", stringify!($name))),
+                $stack_name,
                 "App.java"
             );
 
             #[cfg(feature = "typescript")]
-            test_case!($name, typescript, &Typescript {}, "app.ts");
+            test_case!($name, typescript, &Typescript {}, $stack_name, "app.ts");
         }
     };
 
-    ($name:ident, $lang:ident, $synthesizer:expr, $expected:literal) => {
+    ($name:ident, $lang:ident, $synthesizer:expr, $stack_name:literal, $expected:literal) => {
         #[test]
         fn $lang() {
             let expected = include_str!(concat!("end-to-end/", stringify!($name), "/", $expected));
@@ -36,7 +37,7 @@ macro_rules! test_case {
                 )))
                 .unwrap();
                 let ir = CloudformationProgramIr::from(cfn).unwrap();
-                ir.synthesize($synthesizer, &mut output).unwrap();
+                ir.synthesize($synthesizer, &mut output, $stack_name).unwrap();
                 String::from_utf8(output).unwrap()
             };
 
@@ -50,8 +51,9 @@ macro_rules! test_case {
     };
 }
 
-test_case!(simple);
-test_case!(vpc);
+test_case!(simple, "SimpleStack");
+
+test_case!(vpc, "VpcStack");
 
 struct UpdateSnapshot<'a> {
     path: &'static str,

--- a/tests/end-to-end.rs
+++ b/tests/end-to-end.rs
@@ -8,7 +8,13 @@ macro_rules! test_case {
             use super::*;
 
             #[cfg(feature = "golang")]
-            test_case!($name, golang, &Golang::new(stringify!($name)), $stack_name, "app.go");
+            test_case!(
+                $name,
+                golang,
+                &Golang::new(stringify!($name)),
+                $stack_name,
+                "app.go"
+            );
 
             #[cfg(feature = "java")]
             test_case!(
@@ -37,7 +43,8 @@ macro_rules! test_case {
                 )))
                 .unwrap();
                 let ir = CloudformationProgramIr::from(cfn).unwrap();
-                ir.synthesize($synthesizer, &mut output, $stack_name).unwrap();
+                ir.synthesize($synthesizer, &mut output, $stack_name)
+                    .unwrap();
                 String::from_utf8(output).unwrap()
             };
 

--- a/tests/end-to-end/simple/App.java
+++ b/tests/end-to-end/simple/App.java
@@ -21,15 +21,15 @@ public class NoctApp {
       .description("An example stack that uses many of the syntax elements permitted in a" + 
         "CloudFormation template, but does not attempt to represent a realistic stack.")
       .build();
-    new NoctStack(app, "MyProjectStack", props);
+    new SimpleStack(app, "MyProjectStack", props);
     app.synth();
   }
 }
 
-interface NoctStackProps extends StackProps {
+interface SimpleStackProps extends StackProps {
 }
 
-class NoctStack extends Stack {
+class SimpleStack extends Stack {
   private CfnOutput bucketArn, queueArn, isLarge;
 
   public CfnOutput getBucketArn() {
@@ -41,10 +41,10 @@ class NoctStack extends Stack {
   public CfnOutput getIsLarge() {
     return this.isLarge;
   }
-  public NoctStack(final Construct scope, final String id) {
+  public SimpleStack(final Construct scope, final String id) {
     super(scope, id, null);
   }
-  public NoctStack(final Construct scope, final String id, final StackProps props) {
+  public SimpleStack(final Construct scope, final String id, final StackProps props) {
     super(scope, id, props);
     // Start Mapping section
     final Mapping<Boolean> booleans = new Mapping<>(this, "Booleans");

--- a/tests/end-to-end/simple/app.go
+++ b/tests/end-to-end/simple/app.go
@@ -16,8 +16,8 @@ type SimpleStackProps struct {
 	BucketNamePrefix *string
 }
 
-// / An example stack that uses many of the syntax elements permitted in a
-// / CloudFormation template, but does not attempt to represent a realistic stack.
+/// An example stack that uses many of the syntax elements permitted in a
+/// CloudFormation template, but does not attempt to represent a realistic stack.
 type SimpleStack struct {
 	cdk.Stack
 	/// The ARN of the bucket in this template!
@@ -30,40 +30,40 @@ type SimpleStack struct {
 
 func NewSimpleStack(scope constructs.Construct, id string, props SimpleStackProps) *SimpleStack {
 	/*
-		booleans := map[*string]map[*string]*bool{
-			jsii.String("True"): map[*string]*bool{
-				jsii.String("true"): jsii.Bool(true),
-			},
-			jsii.String("False"): map[*string]*bool{
-				jsii.String("false"): jsii.Bool(false),
-			},
-		}
+	booleans := map[*string]map[*string]*bool{
+		jsii.String("True"): map[*string]*bool{
+			jsii.String("true"): jsii.Bool(true),
+		},
+		jsii.String("False"): map[*string]*bool{
+			jsii.String("false"): jsii.Bool(false),
+		},
+	}
 	*/
 
 	/*
-		lists := map[*string]map[*string][]*string{
-			jsii.String("Candidates"): map[*string][]*string{
-				jsii.String("Empty"): []*string{
-				},
-				jsii.String("Singleton"): []*string{
-					jsii.String("One"),
-				},
-				jsii.String("Pair"): []*string{
-					jsii.String("One"),
-					jsii.String("Two"),
-				},
+	lists := map[*string]map[*string][]*string{
+		jsii.String("Candidates"): map[*string][]*string{
+			jsii.String("Empty"): []*string{
 			},
-		}
+			jsii.String("Singleton"): []*string{
+				jsii.String("One"),
+			},
+			jsii.String("Pair"): []*string{
+				jsii.String("One"),
+				jsii.String("Two"),
+			},
+		},
+	}
 	*/
 
 	/*
-		numbers := map[*string]map[*string]*float64{
-			jsii.String("Prime"): map[*string]*float64{
-				jsii.String("Eleven"): jsii.Number(11),
-				jsii.String("Thirteen"): jsii.Number(13),
-				jsii.String("Seventeen"): jsii.Number(17),
-			},
-		}
+	numbers := map[*string]map[*string]*float64{
+		jsii.String("Prime"): map[*string]*float64{
+			jsii.String("Eleven"): jsii.Number(11),
+			jsii.String("Thirteen"): jsii.Number(13),
+			jsii.String("Seventeen"): jsii.Number(17),
+		},
+	}
 	*/
 
 	strings := map[*string]map[*string]*string{
@@ -79,7 +79,7 @@ func NewSimpleStack(scope constructs.Construct, id string, props SimpleStackProp
 	table := map[*string]map[*string]interface{}{
 		jsii.String("Values"): map[*string]interface{}{
 			jsii.String("Boolean"): jsii.Bool(true),
-			jsii.String("Float"):   jsii.Number(3.14),
+			jsii.String("Float"): jsii.Number(3.14),
 			jsii.String("List"): []*string{
 				jsii.String("1"),
 				jsii.String("2"),
@@ -102,15 +102,15 @@ func NewSimpleStack(scope constructs.Construct, id string, props SimpleStackProp
 		stack,
 		jsii.String("Queue"),
 		&sqs.CfnQueueProps{
-			DelaySeconds:   jsii.Number(42.1337),
-			FifoQueue:      jsii.Bool(false),
+			DelaySeconds: jsii.Number(42.1337),
+			FifoQueue: jsii.Bool(false),
 			KmsMasterKeyId: cdk.Fn_ImportValue(jsii.String("Shared.KmsKeyArn")),
 			QueueName: cdk.Fn_Join(jsii.String("-"), &[]*string{
 				stack.StackName(),
 				strings[jsii.String("Bars")][jsii.String("Bar")],
 				cdk.Fn_Select(jsii.Number(1), cdk.Fn_GetAzs(stack.Region())),
 			}),
-			RedrivePolicy:     nil,
+			RedrivePolicy: nil,
 			VisibilityTimeout: jsii.Number(120),
 		},
 	)
@@ -120,7 +120,7 @@ func NewSimpleStack(scope constructs.Construct, id string, props SimpleStackProp
 		jsii.String("Bucket"),
 		&s3.CfnBucketProps{
 			AccessControl: jsii.String("private"),
-			BucketName:    jsii.String(fmt.Sprintf("%v-%v-bucket", props.BucketNamePrefix, stack.StackName())),
+			BucketName: jsii.String(fmt.Sprintf("%v-%v-bucket", props.BucketNamePrefix, stack.StackName())),
 			Tags: &[]*cdk.CfnTag{
 				&cdk.CfnTag{
 					Key: jsii.String("FancyTag"),
@@ -136,14 +136,14 @@ func NewSimpleStack(scope constructs.Construct, id string, props SimpleStackProp
 
 	cdk.NewCfnOutput(stack, jsii.String("BucketArn"), &cdk.CfnOutputProps{
 		Description: jsii.String("The ARN of the bucket in this template!"),
-		ExportName:  jsii.String("ExportName"),
-		Value:       bucket.AttrArn(),
+		ExportName: jsii.String("ExportName"),
+		Value: bucket.AttrArn(),
 	})
 
 	return &SimpleStack{
-		Stack:     stack,
+		Stack: stack,
 		BucketArn: bucket.AttrArn(),
-		QueueArn:  queue.Ref(),
+		QueueArn: queue.Ref(),
 		IsLarge: ifCondition(
 			isLargeRegion,
 			jsii.Bool(true),
@@ -152,10 +152,10 @@ func NewSimpleStack(scope constructs.Construct, id string, props SimpleStackProp
 	}
 }
 
-// / ifCondition is a helper function that replicates the ternary
-// / operator that can be found in other languages. It is conceptually
-// / equivalent to writing `cond ? whenTrue : whenFalse`, meaning it
-// / returns `whenTrue` if `cond` is `true`, and `whenFalse` otherwise.
+/// ifCondition is a helper function that replicates the ternary
+/// operator that can be found in other languages. It is conceptually
+/// equivalent to writing `cond ? whenTrue : whenFalse`, meaning it
+/// returns `whenTrue` if `cond` is `true`, and `whenFalse` otherwise.
 func ifCondition[T any](cond bool, whenTrue T, whenFalse T) T {
 	if cond {
 		return whenTrue

--- a/tests/end-to-end/simple/app.go
+++ b/tests/end-to-end/simple/app.go
@@ -10,15 +10,15 @@ import (
 	"github.com/aws/jsii-runtime-go"
 )
 
-type NoctStackProps struct {
+type SimpleStackProps struct {
 	cdk.StackProps
 	/// The prefix for the bucket name
 	BucketNamePrefix *string
 }
 
-/// An example stack that uses many of the syntax elements permitted in a
-/// CloudFormation template, but does not attempt to represent a realistic stack.
-type NoctStack struct {
+// / An example stack that uses many of the syntax elements permitted in a
+// / CloudFormation template, but does not attempt to represent a realistic stack.
+type SimpleStack struct {
 	cdk.Stack
 	/// The ARN of the bucket in this template!
 	BucketArn interface{} // TODO: fix to appropriate type
@@ -28,42 +28,42 @@ type NoctStack struct {
 	IsLarge interface{} // TODO: fix to appropriate type
 }
 
-func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *NoctStack {
+func NewSimpleStack(scope constructs.Construct, id string, props SimpleStackProps) *SimpleStack {
 	/*
-	booleans := map[*string]map[*string]*bool{
-		jsii.String("True"): map[*string]*bool{
-			jsii.String("true"): jsii.Bool(true),
-		},
-		jsii.String("False"): map[*string]*bool{
-			jsii.String("false"): jsii.Bool(false),
-		},
-	}
+		booleans := map[*string]map[*string]*bool{
+			jsii.String("True"): map[*string]*bool{
+				jsii.String("true"): jsii.Bool(true),
+			},
+			jsii.String("False"): map[*string]*bool{
+				jsii.String("false"): jsii.Bool(false),
+			},
+		}
 	*/
 
 	/*
-	lists := map[*string]map[*string][]*string{
-		jsii.String("Candidates"): map[*string][]*string{
-			jsii.String("Empty"): []*string{
+		lists := map[*string]map[*string][]*string{
+			jsii.String("Candidates"): map[*string][]*string{
+				jsii.String("Empty"): []*string{
+				},
+				jsii.String("Singleton"): []*string{
+					jsii.String("One"),
+				},
+				jsii.String("Pair"): []*string{
+					jsii.String("One"),
+					jsii.String("Two"),
+				},
 			},
-			jsii.String("Singleton"): []*string{
-				jsii.String("One"),
-			},
-			jsii.String("Pair"): []*string{
-				jsii.String("One"),
-				jsii.String("Two"),
-			},
-		},
-	}
+		}
 	*/
 
 	/*
-	numbers := map[*string]map[*string]*float64{
-		jsii.String("Prime"): map[*string]*float64{
-			jsii.String("Eleven"): jsii.Number(11),
-			jsii.String("Thirteen"): jsii.Number(13),
-			jsii.String("Seventeen"): jsii.Number(17),
-		},
-	}
+		numbers := map[*string]map[*string]*float64{
+			jsii.String("Prime"): map[*string]*float64{
+				jsii.String("Eleven"): jsii.Number(11),
+				jsii.String("Thirteen"): jsii.Number(13),
+				jsii.String("Seventeen"): jsii.Number(17),
+			},
+		}
 	*/
 
 	strings := map[*string]map[*string]*string{
@@ -79,7 +79,7 @@ func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *
 	table := map[*string]map[*string]interface{}{
 		jsii.String("Values"): map[*string]interface{}{
 			jsii.String("Boolean"): jsii.Bool(true),
-			jsii.String("Float"): jsii.Number(3.14),
+			jsii.String("Float"):   jsii.Number(3.14),
 			jsii.String("List"): []*string{
 				jsii.String("1"),
 				jsii.String("2"),
@@ -102,15 +102,15 @@ func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *
 		stack,
 		jsii.String("Queue"),
 		&sqs.CfnQueueProps{
-			DelaySeconds: jsii.Number(42.1337),
-			FifoQueue: jsii.Bool(false),
+			DelaySeconds:   jsii.Number(42.1337),
+			FifoQueue:      jsii.Bool(false),
 			KmsMasterKeyId: cdk.Fn_ImportValue(jsii.String("Shared.KmsKeyArn")),
 			QueueName: cdk.Fn_Join(jsii.String("-"), &[]*string{
 				stack.StackName(),
 				strings[jsii.String("Bars")][jsii.String("Bar")],
 				cdk.Fn_Select(jsii.Number(1), cdk.Fn_GetAzs(stack.Region())),
 			}),
-			RedrivePolicy: nil,
+			RedrivePolicy:     nil,
 			VisibilityTimeout: jsii.Number(120),
 		},
 	)
@@ -120,7 +120,7 @@ func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *
 		jsii.String("Bucket"),
 		&s3.CfnBucketProps{
 			AccessControl: jsii.String("private"),
-			BucketName: jsii.String(fmt.Sprintf("%v-%v-bucket", props.BucketNamePrefix, stack.StackName())),
+			BucketName:    jsii.String(fmt.Sprintf("%v-%v-bucket", props.BucketNamePrefix, stack.StackName())),
 			Tags: &[]*cdk.CfnTag{
 				&cdk.CfnTag{
 					Key: jsii.String("FancyTag"),
@@ -136,14 +136,14 @@ func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *
 
 	cdk.NewCfnOutput(stack, jsii.String("BucketArn"), &cdk.CfnOutputProps{
 		Description: jsii.String("The ARN of the bucket in this template!"),
-		ExportName: jsii.String("ExportName"),
-		Value: bucket.AttrArn(),
+		ExportName:  jsii.String("ExportName"),
+		Value:       bucket.AttrArn(),
 	})
 
-	return &NoctStack{
-		Stack: stack,
+	return &SimpleStack{
+		Stack:     stack,
 		BucketArn: bucket.AttrArn(),
-		QueueArn: queue.Ref(),
+		QueueArn:  queue.Ref(),
 		IsLarge: ifCondition(
 			isLargeRegion,
 			jsii.Bool(true),
@@ -152,10 +152,10 @@ func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *
 	}
 }
 
-/// ifCondition is a helper function that replicates the ternary
-/// operator that can be found in other languages. It is conceptually
-/// equivalent to writing `cond ? whenTrue : whenFalse`, meaning it
-/// returns `whenTrue` if `cond` is `true`, and `whenFalse` otherwise.
+// / ifCondition is a helper function that replicates the ternary
+// / operator that can be found in other languages. It is conceptually
+// / equivalent to writing `cond ? whenTrue : whenFalse`, meaning it
+// / returns `whenTrue` if `cond` is `true`, and `whenFalse` otherwise.
 func ifCondition[T any](cond bool, whenTrue T, whenFalse T) T {
 	if cond {
 		return whenTrue

--- a/tests/end-to-end/simple/app.ts
+++ b/tests/end-to-end/simple/app.ts
@@ -3,7 +3,7 @@ import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
 import { Buffer } from 'buffer';
 
-export interface NoctStackProps extends cdk.StackProps {
+export interface SimpleStackProps extends cdk.StackProps {
   /**
    * The prefix for the bucket name
    * @default "bucket"
@@ -15,7 +15,7 @@ export interface NoctStackProps extends cdk.StackProps {
  * An example stack that uses many of the syntax elements permitted in a
  * CloudFormation template, but does not attempt to represent a realistic stack.
  */
-export class NoctStack extends cdk.Stack {
+export class SimpleStack extends cdk.Stack {
   /**
    * The ARN of the bucket in this template!
    */
@@ -29,7 +29,7 @@ export class NoctStack extends cdk.Stack {
    */
   public readonly isLarge;
 
-  public constructor(scope: cdk.App, id: string, props: NoctStackProps = {}) {
+  public constructor(scope: cdk.App, id: string, props: SimpleStackProps = {}) {
     super(scope, id, props);
 
     // Applying default props

--- a/tests/end-to-end/vpc/App.java
+++ b/tests/end-to-end/vpc/App.java
@@ -19,19 +19,19 @@ public class NoctApp {
     StackProps props = StackProps.builder()
       ""
       .build();
-    new NoctStack(app, "MyProjectStack", props);
+    new VpcStack(app, "MyProjectStack", props);
     app.synth();
   }
 }
 
-interface NoctStackProps extends StackProps {
+interface VpcStackProps extends StackProps {
 }
 
-class NoctStack extends Stack {
-  public NoctStack(final Construct scope, final String id) {
+class VpcStack extends Stack {
+  public VpcStack(final Construct scope, final String id) {
     super(scope, id, null);
   }
-  public NoctStack(final Construct scope, final String id, final StackProps props) {
+  public VpcStack(final Construct scope, final String id, final StackProps props) {
     super(scope, id, props);
     // Start Mapping section
 

--- a/tests/end-to-end/vpc/app.go
+++ b/tests/end-to-end/vpc/app.go
@@ -7,27 +7,27 @@ import (
 	"github.com/aws/jsii-runtime-go"
 )
 
-type NoctStackProps struct {
+type VpcStackProps struct {
 	cdk.StackProps
 }
 
-type NoctStack struct {
+type VpcStack struct {
 	cdk.Stack
 }
 
-func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *NoctStack {
+func NewVpcStack(scope constructs.Construct, id string, props VpcStackProps) *VpcStack {
 	stack := cdk.NewStack(scope, &id, &props.StackProps)
 
 	vpc := ec2.NewCfnVPC(
 		stack,
 		jsii.String("VPC"),
 		&ec2.CfnVPCProps{
-			CidrBlock: jsii.String("10.42.0.0/16"),
-			EnableDnsSupport: jsii.Bool(true),
+			CidrBlock:          jsii.String("10.42.0.0/16"),
+			EnableDnsSupport:   jsii.Bool(true),
 			EnableDnsHostnames: jsii.Bool(true),
 			Tags: &[]*cdk.CfnTag{
 				&cdk.CfnTag{
-					Key: jsii.String("cost-center"),
+					Key:   jsii.String("cost-center"),
 					Value: jsii.Number(1337),
 				},
 			},
@@ -39,8 +39,8 @@ func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *
 		jsii.String("Subnet1"),
 		&ec2.CfnSubnetProps{
 			AvailabilityZone: cdk.Fn_Select(jsii.Number(0), cdk.Fn_GetAzs(jsii.String(""))),
-			CidrBlock: cdk.Fn_Select(jsii.Number(0), cdk.Fn_Cidr(vpc.AttrCidrBlock(), jsii.Number(6), jsii.String("8"))),
-			VpcId: vpc.Ref(),
+			CidrBlock:        cdk.Fn_Select(jsii.Number(0), cdk.Fn_Cidr(vpc.AttrCidrBlock(), jsii.Number(6), jsii.String("8"))),
+			VpcId:            vpc.Ref(),
 		},
 	)
 
@@ -49,8 +49,8 @@ func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *
 		jsii.String("Subnet2"),
 		&ec2.CfnSubnetProps{
 			AvailabilityZone: cdk.Fn_Select(jsii.Number(1), cdk.Fn_GetAzs(jsii.String(""))),
-			CidrBlock: cdk.Fn_Select(jsii.Number(1), cdk.Fn_Cidr(vpc.AttrCidrBlock(), jsii.Number(6), jsii.String("8"))),
-			VpcId: vpc.Ref(),
+			CidrBlock:        cdk.Fn_Select(jsii.Number(1), cdk.Fn_Cidr(vpc.AttrCidrBlock(), jsii.Number(6), jsii.String("8"))),
+			VpcId:            vpc.Ref(),
 		},
 	)
 
@@ -59,12 +59,12 @@ func NewNoctStack(scope constructs.Construct, id string, props NoctStackProps) *
 		jsii.String("Subnet3"),
 		&ec2.CfnSubnetProps{
 			AvailabilityZone: cdk.Fn_Select(jsii.Number(2), cdk.Fn_GetAzs(jsii.String(""))),
-			CidrBlock: cdk.Fn_Select(jsii.Number(2), cdk.Fn_Cidr(vpc.AttrCidrBlock(), jsii.Number(6), jsii.String("8"))),
-			VpcId: vpc.Ref(),
+			CidrBlock:        cdk.Fn_Select(jsii.Number(2), cdk.Fn_Cidr(vpc.AttrCidrBlock(), jsii.Number(6), jsii.String("8"))),
+			VpcId:            vpc.Ref(),
 		},
 	)
 
-	return &NoctStack{
+	return &VpcStack{
 		Stack: stack,
 	}
 }

--- a/tests/end-to-end/vpc/app.go
+++ b/tests/end-to-end/vpc/app.go
@@ -22,12 +22,12 @@ func NewVpcStack(scope constructs.Construct, id string, props VpcStackProps) *Vp
 		stack,
 		jsii.String("VPC"),
 		&ec2.CfnVPCProps{
-			CidrBlock:          jsii.String("10.42.0.0/16"),
-			EnableDnsSupport:   jsii.Bool(true),
+			CidrBlock: jsii.String("10.42.0.0/16"),
+			EnableDnsSupport: jsii.Bool(true),
 			EnableDnsHostnames: jsii.Bool(true),
 			Tags: &[]*cdk.CfnTag{
 				&cdk.CfnTag{
-					Key:   jsii.String("cost-center"),
+					Key: jsii.String("cost-center"),
 					Value: jsii.Number(1337),
 				},
 			},
@@ -39,8 +39,8 @@ func NewVpcStack(scope constructs.Construct, id string, props VpcStackProps) *Vp
 		jsii.String("Subnet1"),
 		&ec2.CfnSubnetProps{
 			AvailabilityZone: cdk.Fn_Select(jsii.Number(0), cdk.Fn_GetAzs(jsii.String(""))),
-			CidrBlock:        cdk.Fn_Select(jsii.Number(0), cdk.Fn_Cidr(vpc.AttrCidrBlock(), jsii.Number(6), jsii.String("8"))),
-			VpcId:            vpc.Ref(),
+			CidrBlock: cdk.Fn_Select(jsii.Number(0), cdk.Fn_Cidr(vpc.AttrCidrBlock(), jsii.Number(6), jsii.String("8"))),
+			VpcId: vpc.Ref(),
 		},
 	)
 
@@ -49,8 +49,8 @@ func NewVpcStack(scope constructs.Construct, id string, props VpcStackProps) *Vp
 		jsii.String("Subnet2"),
 		&ec2.CfnSubnetProps{
 			AvailabilityZone: cdk.Fn_Select(jsii.Number(1), cdk.Fn_GetAzs(jsii.String(""))),
-			CidrBlock:        cdk.Fn_Select(jsii.Number(1), cdk.Fn_Cidr(vpc.AttrCidrBlock(), jsii.Number(6), jsii.String("8"))),
-			VpcId:            vpc.Ref(),
+			CidrBlock: cdk.Fn_Select(jsii.Number(1), cdk.Fn_Cidr(vpc.AttrCidrBlock(), jsii.Number(6), jsii.String("8"))),
+			VpcId: vpc.Ref(),
 		},
 	)
 
@@ -59,8 +59,8 @@ func NewVpcStack(scope constructs.Construct, id string, props VpcStackProps) *Vp
 		jsii.String("Subnet3"),
 		&ec2.CfnSubnetProps{
 			AvailabilityZone: cdk.Fn_Select(jsii.Number(2), cdk.Fn_GetAzs(jsii.String(""))),
-			CidrBlock:        cdk.Fn_Select(jsii.Number(2), cdk.Fn_Cidr(vpc.AttrCidrBlock(), jsii.Number(6), jsii.String("8"))),
-			VpcId:            vpc.Ref(),
+			CidrBlock: cdk.Fn_Select(jsii.Number(2), cdk.Fn_Cidr(vpc.AttrCidrBlock(), jsii.Number(6), jsii.String("8"))),
+			VpcId: vpc.Ref(),
 		},
 	)
 

--- a/tests/end-to-end/vpc/app.ts
+++ b/tests/end-to-end/vpc/app.ts
@@ -1,11 +1,11 @@
 import * as cdk from 'aws-cdk-lib';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 
-export interface NoctStackProps extends cdk.StackProps {
+export interface VpcStackProps extends cdk.StackProps {
 }
 
-export class NoctStack extends cdk.Stack {
-  public constructor(scope: cdk.App, id: string, props: NoctStackProps = {}) {
+export class VpcStack extends cdk.Stack {
+  public constructor(scope: cdk.App, id: string, props: VpcStackProps = {}) {
     super(scope, id, props);
 
     // Resources


### PR DESCRIPTION
This change adds a CLI input `--stack-name` that users can specify. The default value of `NoctStack` is unchanged if no input is provided by the user.