### PR TITLE
feat: support non primitive parameters

### DIFF
--- a/src/synthesizer/java/mod.rs
+++ b/src/synthesizer/java/mod.rs
@@ -10,6 +10,7 @@ use crate::parser::lookup_table::MappingInnerValue;
 use crate::specification::{CfnType, Structure};
 use std::borrow::Cow;
 use std::collections::LinkedList;
+use std::fmt::format;
 use std::io;
 use std::rc::Rc;
 use voca_rs::case::{camel_case, pascal_case};
@@ -92,7 +93,7 @@ impl Java {
                 ".description(\"{}\")",
                 desc.replace("\n", "\" + \n  \"")
             )),
-            None => stack_prop.line("\"\""),
+            None => {},
         };
         main.line(format!(
             "new {}(app, \"MyProjectStack\", props);",
@@ -211,10 +212,15 @@ class Mapping<T> {
     fn write_parameters(ir: &CloudformationProgramIr, writer: &Rc<CodeBuffer>) {
         for input in &ir.constructor.inputs {
             let name = camel_case(&input.name);
+            let java_type = match input.constructor_type.as_str() {
+                t if t.contains("List") => "List<String>",
+                _ => "String",
+            };
             writer.line(format!(
-                "CfnParameter {name} = CfnParameter.Builder.create(this, \"{}\")",
-                &input.name
+                "final {java_type} {name} = CfnParameter.Builder.create(this, \"{}\")",
+                pascal_case(&input.name)
             ));
+            writer.indent(INDENT).line(format!(".type(\"{}\")", &input.constructor_type));
             match &input.description {
                 Some(descr) => writer
                     .indent(INDENT)
@@ -223,12 +229,15 @@ class Mapping<T> {
             };
             match &input.default_value {
                 Some(val) => writer.indent(INDENT).line(format!(
-                    ".defaultValue({}.valueOf(\"{}\"))",
-                    &input.constructor_type, val
+                    ".defaultValue(\"{}\")", val
                 )),
                 None => {}
             };
-            writer.line(format!("{INDENT}.build();"))
+            writer.indent(INDENT).line(".build()");
+            match input.constructor_type.as_str() {
+                t if t.contains("List") => writer.indent(INDENT).line(".getValueAsStringList();"),
+                _ => writer.indent(INDENT).line(".getValueAsString();"),
+            };
         }
     }
 
@@ -257,7 +266,7 @@ class Mapping<T> {
             });
             for (key, value) in &resource.properties {
                 let property = camel_case(key.as_str());
-                let value = emit_java(value.clone(), None);
+                let value = emit_java(value.clone(), Some(format!("Cfn{class}").as_str()));
                 properties.line(format!(".{property}({value})"));
             }
             writer.newline();
@@ -588,18 +597,33 @@ fn emit_java(this: ResourceIr, trailer: Option<&str>) -> String {
         ResourceIr::ImportValue(text) => format!("\"{text}\""),
 
         ResourceIr::Object(structure, index_map) => match structure {
-            Structure::Composite(_) => {
-                let mut res = format!("new GenericMap<String, Object>()");
-                for (key, value) in &index_map {
-                    let element = emit_java((*value).clone(), None);
-                    if key.eq_ignore_ascii_case("Key") {
-                        res = br!(res, format!(".extend({}", element))
-                    }
-                    if key.eq_ignore_ascii_case("Value") {
-                        res = format!("{res},{})", element)
-                    }
+            Structure::Composite(property) => {
+                match property {
+                    "Tag" => {
+                        let mut res = format!("new GenericMap<String, Object>()");
+                        for (key, value) in &index_map {
+                            let element = emit_java((*value).clone(), None);
+                            if key.eq_ignore_ascii_case("Key") {
+                                res = br!(res, format!(".extend({}", element))
+                            }
+                            if key.eq_ignore_ascii_case("Value") {
+                                res = format!("{res},{})", element)
+                            }
+                        }
+                        br!(res, ".getTags()")
+                    },
+                    _ => {
+                        let mut res = format!("{}.{property}Property.builder()", match trailer {
+                            Some(v) => v,
+                            None => "",
+                        });
+                        for (key, value) in &index_map {
+                            let element = emit_java((*value).clone(), trailer);
+                            res = br!(res, format!(".{}({})", camel_case(key), element));
+                        }
+                        br!(res, ".build()")
+                    },
                 }
-                br!(res, ".getTags()")
             }
 
             Structure::Simple(cfn_type) => {

--- a/src/synthesizer/java/mod.rs
+++ b/src/synthesizer/java/mod.rs
@@ -92,7 +92,7 @@ impl Java {
                 ".description(\"{}\")",
                 desc.replace("\n", "\" + \n  \"")
             )),
-            None => {},
+            None => {}
         };
         main.line(format!(
             "new {}(app, \"MyProjectStack\", props);",
@@ -219,7 +219,9 @@ class Mapping<T> {
                 "final {java_type} {name} = CfnParameter.Builder.create(this, \"{}\")",
                 pascal_case(&input.name)
             ));
-            writer.indent(INDENT).line(format!(".type(\"{}\")", &input.constructor_type));
+            writer
+                .indent(INDENT)
+                .line(format!(".type(\"{}\")", &input.constructor_type));
             match &input.description {
                 Some(descr) => writer
                     .indent(INDENT)
@@ -227,9 +229,9 @@ class Mapping<T> {
                 None => {}
             };
             match &input.default_value {
-                Some(val) => writer.indent(INDENT).line(format!(
-                    ".defaultValue(\"{}\")", val
-                )),
+                Some(val) => writer
+                    .indent(INDENT)
+                    .line(format!(".defaultValue(\"{}\")", val)),
                 None => {}
             };
             writer.indent(INDENT).line(".build()");
@@ -596,34 +598,35 @@ fn emit_java(this: ResourceIr, trailer: Option<&str>) -> String {
         ResourceIr::ImportValue(text) => format!("\"{text}\""),
 
         ResourceIr::Object(structure, index_map) => match structure {
-            Structure::Composite(property) => {
-                match property {
-                    "Tag" => {
-                        let mut res = format!("new GenericMap<String, Object>()");
-                        for (key, value) in &index_map {
-                            let element = emit_java((*value).clone(), None);
-                            if key.eq_ignore_ascii_case("Key") {
-                                res = br!(res, format!(".extend({}", element))
-                            }
-                            if key.eq_ignore_ascii_case("Value") {
-                                res = format!("{res},{})", element)
-                            }
+            Structure::Composite(property) => match property {
+                "Tag" => {
+                    let mut res = format!("new GenericMap<String, Object>()");
+                    for (key, value) in &index_map {
+                        let element = emit_java((*value).clone(), None);
+                        if key.eq_ignore_ascii_case("Key") {
+                            res = br!(res, format!(".extend({}", element))
                         }
-                        br!(res, ".getTags()")
-                    },
-                    _ => {
-                        let mut res = format!("{}.{property}Property.builder()", match trailer {
+                        if key.eq_ignore_ascii_case("Value") {
+                            res = format!("{res},{})", element)
+                        }
+                    }
+                    br!(res, ".getTags()")
+                }
+                _ => {
+                    let mut res = format!(
+                        "{}.{property}Property.builder()",
+                        match trailer {
                             Some(v) => v,
                             None => "",
-                        });
-                        for (key, value) in &index_map {
-                            let element = emit_java((*value).clone(), trailer);
-                            res = br!(res, format!(".{}({})", camel_case(key), element));
                         }
-                        br!(res, ".build()")
-                    },
+                    );
+                    for (key, value) in &index_map {
+                        let element = emit_java((*value).clone(), trailer);
+                        res = br!(res, format!(".{}({})", camel_case(key), element));
+                    }
+                    br!(res, ".build()")
                 }
-            }
+            },
 
             Structure::Simple(cfn_type) => {
                 let mut res = format!("new GenericMap<String, {}>()", match_cfn_type(&cfn_type));

--- a/src/synthesizer/java/mod.rs
+++ b/src/synthesizer/java/mod.rs
@@ -10,7 +10,6 @@ use crate::parser::lookup_table::MappingInnerValue;
 use crate::specification::{CfnType, Structure};
 use std::borrow::Cow;
 use std::collections::LinkedList;
-use std::fmt::format;
 use std::io;
 use std::rc::Rc;
 use voca_rs::case::{camel_case, pascal_case};

--- a/tests/end-to-end/simple/app.go
+++ b/tests/end-to-end/simple/app.go
@@ -14,6 +14,7 @@ type SimpleStackProps struct {
 	cdk.StackProps
 	/// The prefix for the bucket name
 	BucketNamePrefix *string
+	LogDestinationBucketName interface{/* AWS::SSM::Parameter::Value<String> */}
 }
 
 /// An example stack that uses many of the syntax elements permitted in a
@@ -121,6 +122,17 @@ func NewSimpleStack(scope constructs.Construct, id string, props SimpleStackProp
 		&s3.CfnBucketProps{
 			AccessControl: jsii.String("private"),
 			BucketName: jsii.String(fmt.Sprintf("%v-%v-bucket", props.BucketNamePrefix, stack.StackName())),
+			LoggingConfiguration: &LoggingConfiguration/* FIXME */{
+				DestinationBucketName: props.LogDestinationBucketName,
+			},
+			WebsiteConfiguration: &WebsiteConfiguration/* FIXME */{
+				IndexDocument: jsii.String("index.html"),
+				ErrorDocument: jsii.String("error.html"),
+				RedirectAllRequestsTo: &RedirectAllRequestsTo/* FIXME */{
+					HostName: jsii.String("example.com"),
+					Protocol: jsii.String("https"),
+				},
+			},
 			Tags: &[]*cdk.CfnTag{
 				&cdk.CfnTag{
 					Key: jsii.String("FancyTag"),

--- a/tests/end-to-end/simple/template.yml
+++ b/tests/end-to-end/simple/template.yml
@@ -52,7 +52,9 @@ Parameters:
     Type: String
     Default: bucket
     Description: "The prefix for the bucket name"
-
+  LogDestinationBucketName:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /logging/bucket/name
 Resources:
   Bucket:
     Condition: IsUsEast1
@@ -60,6 +62,14 @@ Resources:
     Properties:
       AccessControl: !Base64 'cHJpdmF0ZQ=='
       BucketName: !Sub ${BucketNamePrefix}-${AWS::StackName}-bucket
+      LoggingConfiguration:
+        DestinationBucketName: !Ref LogDestinationBucketName
+      WebsiteConfiguration:
+        IndexDocument: index.html
+        ErrorDocument: error.html
+        RedirectAllRequestsTo:
+          HostName: example.com
+          Protocol: https
       Tags:
         - Key: FancyTag
           Value:

--- a/tests/end-to-end/vpc/App.java
+++ b/tests/end-to-end/vpc/App.java
@@ -17,7 +17,6 @@ public class NoctApp {
   public static void main(final String[] args) {
     App app = new App();
     StackProps props = StackProps.builder()
-      ""
       .build();
     new VpcStack(app, "MyProjectStack", props);
     app.synth();


### PR DESCRIPTION
## Summary
Support non primitive parameters for TypeScript and Java. (e.g `AWS::EC2::VPC::Id`, `AWS::SSM::Parameter::Value<String>`)

## Why need this change?
Currently, noctilucent looks like support only String type parameter. For example, we can't restore a project even if it's just initialized with CDK.

The steps to reproduce are as follows

1. npx cdk init app --language typescript
2. npx cdk synth
3. cp ./cdk.out/XxxStack.template.json ./template.txt
4. mkdir migrate
5. cd migrate
6. npx cdk migrate

then got this code (`lib/generated_stack.ts`)

```ts
import * as cdk from 'aws-cdk-lib';
import * as cdk from 'aws-cdk-lib/aws-cdk';

export interface NoctStackProps extends cdk.StackProps {
  /**
   * Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]
   * @default /cdk-bootstrap/hnb659fds/version
   */
  readonly bootstrapVersion?: awsSsmParameterValueString;
}

export class NoctStack extends cdk.Stack {
  public constructor(scope: cdk.App, id: string, props: NoctStackProps = {}) {
    super(scope, id, props);

    // Applying default props
    props = {
      ...props,
      bootstrapVersion: props.bootstrapVersion ?? /cdk-bootstrap/hnb659fds/version,
    };

    // Conditions
    const cdkMetadataAvailable = ((this.region === 'af-south-1' || this.region === 'ap-east-1' || this.region === 'ap-northeast-1' || this.region === 'ap-northeast-2' || this.region === 'ap-south-1' || this.region === 'ap-southeast-1' || this.region === 'ap-southeast-2' || this.region === 'ca-central-1' || this.region === 'cn-north-1' || this.region === 'cn-northwest-1') || (this.region === 'eu-central-1' || this.region === 'eu-north-1' || this.region === 'eu-south-1' || this.region === 'eu-west-1' || this.region === 'eu-west-2' || this.region === 'eu-west-3' || this.region === 'me-south-1' || this.region === 'sa-east-1' || this.region === 'us-east-1' || this.region === 'us-east-2') || (this.region === 'us-west-1' || this.region === 'us-west-2'));

    // Resources
    const cdkMetadata = cdkMetadataAvailable
      ? new cdk.CfnMetadata(this, 'CDKMetadata', {
          analytics: 'v2:deflate64:H4sIAAAAAAAA/zPSs7DQM1BMLC/WTU7J1s3JTNKrDi5JTM7WcU7LC0otzi8tSk4FsZ3z81IySzLz82p18vJTUvWyivXLjAz0jPUMFbOKMzN1i0rzSjJzU/WCIDQAi48Ke1gAAAA=',
        })
      : undefined;
    if (cdkMetadata != null) {
      cdkMetadata.cfnOptions.metadata = {
        aws:cdk:path: 'ExampleStack/CDKMetadata/Default',
      };
    }
  }
}
```

We don't found `awsSsmParameterValueString` type and invalid default value.
```ts
export interface NoctStackProps extends cdk.StackProps {
  /**
   * Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]
   * @default /cdk-bootstrap/hnb659fds/version
   */
  readonly bootstrapVersion?: awsSsmParameterValueString;
}
```
```ts
    props = {
      ...props,
      // this line is invalid default value
      bootstrapVersion: props.bootstrapVersion ?? /cdk-bootstrap/hnb659fds/version,
    };
```

This code of PR generate following code
```ts
import * as cdk from 'aws-cdk-lib';
import * as cdk from 'aws-cdk-lib/aws-cdk';

export interface NoctStackProps extends cdk.StackProps {
  /**
   * Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]
   * @default '/cdk-bootstrap/hnb659fds/version'
   */
  readonly bootstrapVersion?: string;
}

export class NoctStack extends cdk.Stack {
  public constructor(scope: cdk.App, id: string, props: NoctStackProps = {}) {
    super(scope, id, props);

    // Applying default props
    props = {
      ...props,
      bootstrapVersion: new cdk.CfnParameter(this, 'BootstrapVersion', {
        type: 'AWS::SSM::Parameter::Value<String>',
        default: props.bootstrapVersion?.toString() ?? '/cdk-bootstrap/hnb659fds/version',
        description: 'Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]',
      }).valueAsString,
    };

    // Conditions
    const cdkMetadataAvailable = ((this.region === 'af-south-1' || this.region === 'ap-east-1' || this.region === 'ap-northeast-1' || this.region === 'ap-northeast-2' || this.region === 'ap-south-1' || this.region === 'ap-southeast-1' || this.region === 'ap-southeast-2' || this.region === 'ca-central-1' || this.region === 'cn-north-1' || this.region === 'cn-northwest-1') || (this.region === 'eu-central-1' || this.region === 'eu-north-1' || this.region === 'eu-south-1' || this.region === 'eu-west-1' || this.region === 'eu-west-2' || this.region === 'eu-west-3' || this.region === 'me-south-1' || this.region === 'sa-east-1' || this.region === 'us-east-1' || this.region === 'us-east-2') || (this.region === 'us-west-1' || this.region === 'us-west-2'));

    // Resources
    const cdkMetadata = cdkMetadataAvailable
      ? new cdk.CfnMetadata(this, 'CDKMetadata', {
          analytics: 'v2:deflate64:H4sIAAAAAAAA/zPSs7DQM1BMLC/WTU7J1s3JTNKrDi5JTM7WcU7LC0otzi8tSk4FsZ3z81IySzLz82p18vJTUvWyivXLjAz0jPUMFbOKMzN1i0rzSjJzU/WCIDQAi48Ke1gAAAA=',
        })
      : undefined;
    if (cdkMetadata != null) {
      cdkMetadata.cfnOptions.metadata = {
        aws:cdk:path: 'ExampleStack/CDKMetadata/Default',
      };
    }
  }
}
```

## CfnParameter is not recommend
Yes, I know. However, the customers who want [noctilucent](https://github.com/iph/noctilucent) need CfnParameter on migration step.